### PR TITLE
Fixed requirement compatibilities. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,28 +1,28 @@
 Django>=1.10,<1.11
-psycopg2>=2.6.2,<3.0
-django-confy>=1.0.4,<2.0
+psycopg2>=2.6.2,<2.7
+django-confy==1.0.4
 django-bootstrap3==6.2.2
 django-auth-ldap==1.2.8
-openpyxl>=2.3.5,<2.4.0
-django-reversion>=1.10,<2.0
-jsontableschema>=0.6.5,<1.0
+openpyxl==2.3.5
+django-reversion==1.10
+jsontableschema==0.6.5
 # force a version of dependency of jsontableschema to avoid warning
 tabulator==0.5.0
-datapackage>=0.8.1
+datapackage==0.8.1
 pytz>=2016.6.1
-django-timezone-field>=2.0rc1,<3.0
-requests>=2.11,<3.0
-Unipath>=1.1,<2.0
+django-timezone-field==2.0
+requests==2.11
+Unipath==1.1
 
 # rest API
 djangorestframework>=3.4.5,<3.5
 coreapi>=2.0,<2.1
 django-filter>=0.14.0,<0.15.0
-django-crispy-forms>=1.6.0,<2.0
-django-rest-swagger>=2.0.5,<3.0
+django-crispy-forms==1.6.0
+django-rest-swagger==2.0.5,<3.0
 django-cors-headers==1.2.0
-dry-rest-permissions>=0.1.6,<1.0
-djangorestframework-gis>=0.10.1,<1.0
+dry-rest-permissions==0.1.6
+djangorestframework-gis==0.10.1
 
 
 
@@ -30,7 +30,7 @@ djangorestframework-gis>=0.10.1,<1.0
 https://static.dpaw.wa.gov.au/static/py/dpaw-utils/dist/dpaw-utils-0.3a9.tar.gz
 
 # TODO: to get rid of
-django-grappelli>=2.8.1
+django-grappelli==2.8.2
 
 
 # suspicious dependencies


### PR DESCRIPTION
A pip --upgrade was creating an error because of jsontableschema and tabulator versions.
Tabulator version was fixed to `tabulator==0.5.0` because above this version it pops-up annoying deprecation warnings. But fixing this version imposed to fix the version of`jsontableschema==0.6.5`

Narrowed requirements version for other libs.
