### PR TITLE
Fix dateutil dayfirst issue

### DIFF
--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -313,21 +313,20 @@ class TestSchemaFieldCast(TestCase):
             with self.assertRaises(Exception):
                 f.cast(v)
 
-        # format='any'. Auto-detect but will use the bloody mm/dd/yyyy american format by default
+        # The main problem is to be sure that a dd/mm/yyyy is not interpreted as mm/dd/yyyy
         descriptor['format'] = 'any'
         f = SchemaField(descriptor)
         valid_values = [
-            '2016-07-29',
-            '07/29/2016',
-            '07/29/16',
-            '2016-07-29 15:28:37',
-            '29/07/2016',
-            '29-July-2016',
-            '29-JUlY-16',
-            '29-07-2016',
-            '29-07-16'
+            '2016-07-10',
+            '10/07/2016',
+            '10/07/16',
+            '2016-07-10 15:28:37',
+            '10-July-2016',
+            '10-JUlY-16',
+            '10-07-2016',
+            '10-07-16'
         ]
-        expected_date = datetime.date(2016, 7, 29)
+        expected_date = datetime.date(2016, 7, 10)
         for v in valid_values:
             date = f.cast(v)
             self.assertIsInstance(date, datetime.date)
@@ -336,10 +335,6 @@ class TestSchemaFieldCast(TestCase):
         for v in invalid_value:
             with self.assertRaises(Exception):
                 f.cast(v)
-        # test that it works in dd/mm/yyyy not mm/dd/yyy
-        date = '01/12/2016'
-        expected = datetime.date(2016, 12, 1)
-        self.assertEqual(f.cast(date), expected)
 
     def test_date_custom_format(self):
         format_ = 'fmt:%d %b %y'  # ex 30 Nov 14

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -57,7 +57,7 @@ class DayFirstDateType(types.DateType):
             return value
         try:
             # there's a 'bug' in dateutil.parser.parse (2.5.3)if you are using
-            # dayfirst=True. It will parse 2016-12-01 as the 12/01/2016 !!
+            # dayfirst=True. It will parse YYYY-MM-DD as YYYY-DD-MM !!
             # https://github.com/dateutil/dateutil/issues/268
             dayfirst = False if YYYY_MM_DD_REGEX.match(value) else True
             return date_parse(value, dayfirst=dayfirst).date()

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -59,7 +59,7 @@ class DayFirstDateType(types.DateType):
             # there's a 'bug' in dateutil.parser.parse (2.5.3)if you are using
             # dayfirst=True. It will parse YYYY-MM-DD as YYYY-DD-MM !!
             # https://github.com/dateutil/dateutil/issues/268
-            dayfirst = False if YYYY_MM_DD_REGEX.match(value) else True
+            dayfirst = not YYYY_MM_DD_REGEX.match(value)
             return date_parse(value, dayfirst=dayfirst).date()
         except (TypeError, ValueError) as e:
             raise_with_traceback(InvalidDateType(e))


### PR DESCRIPTION
Fix the problem of date YYYY-MM-DD being parsed as YYYY-DD-MM by `dateutil.parser.parse`
Changed the test values to cover this test.
