### PR TITLE
Model metadata with options

### DIFF
--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -229,6 +229,7 @@ class ObservationSerializer(GenericRecordSerializer):
     class Meta:
         model = Observation
         list_serializer_class = ObservationListSerializer
+        fields = '__all__'
 
 
 class SpeciesObservationListSerializer(ObservationListSerializer):
@@ -290,3 +291,4 @@ class SpeciesObservationSerializer(ObservationSerializer):
     class Meta:
         model = SpeciesObservation
         list_serializer_class = SpeciesObservationListSerializer
+        fields = '__all__'

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -136,7 +136,7 @@ class DatasetDataView(generics.ListCreateAPIView, SpeciesMixin):
         return ctx
 
     def get_queryset(self):
-        return self.dataset.record_queryset
+        return self.dataset.record_queryset if self.dataset else Dataset.objects.none()
 
     def get(self, request, *args, **kwargs):
         """

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -171,6 +171,9 @@ class Dataset(models.Model):
     def has_metadata_permission(request):
         return True
 
+    def has_object_metadata_permission(self, request):
+        return True
+
     @staticmethod
     def has_create_permission(request):
         """
@@ -254,6 +257,9 @@ class AbstractRecord(models.Model):
 
     @staticmethod
     def has_metadata_permission(request):
+        return True
+
+    def has_object_metadata_permission(self, request):
         return True
 
     @staticmethod
@@ -389,6 +395,9 @@ class Project(models.Model):
     def has_metadata_permission(request):
         return True
 
+    def has_object_metadata_permission(self, request):
+        return True
+
     @staticmethod
     def has_create_permission(request):
         return is_admin(request.user)
@@ -454,6 +463,9 @@ class Site(models.Model):
 
     @staticmethod
     def has_metadata_permission(request):
+        return True
+
+    def has_object_metadata_permission(self, request):
         return True
 
     @staticmethod

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -15,8 +15,8 @@ from django.utils.text import Truncator
 from timezone_field import TimeZoneField
 
 from main.constants import DATUM_CHOICES, MODEL_SRID
-from main.utils_data_package import GenericSchema, ObservationSchema, SpeciesObservationSchema
 from main.utils_auth import is_admin, belongs_to
+from main.utils_data_package import GenericSchema, ObservationSchema, SpeciesObservationSchema
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +168,10 @@ class Dataset(models.Model):
         return True
 
     @staticmethod
+    def has_metadata_permission(request):
+        return True
+
+    @staticmethod
     def has_create_permission(request):
         """
         Custodian and admin only
@@ -246,6 +250,10 @@ class AbstractRecord(models.Model):
         return True
 
     def has_object_read_permission(self, request):
+        return True
+
+    @staticmethod
+    def has_metadata_permission(request):
         return True
 
     @staticmethod
@@ -378,6 +386,10 @@ class Project(models.Model):
         return True
 
     @staticmethod
+    def has_metadata_permission(request):
+        return True
+
+    @staticmethod
     def has_create_permission(request):
         return is_admin(request.user)
 
@@ -438,6 +450,10 @@ class Site(models.Model):
         return True
 
     def has_object_read_permission(self, request):
+        return True
+
+    @staticmethod
+    def has_metadata_permission(request):
         return True
 
     @staticmethod

--- a/biosys/apps/main/tests/api/test_datapackage_data.py
+++ b/biosys/apps/main/tests/api/test_datapackage_data.py
@@ -5,9 +5,9 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from main.models import Project, Site, Dataset, GenericRecord
+from main.tests.api import helpers
 from main.tests.test_data_package import clone
 from main.utils_auth import is_admin
-from main.tests.api import helpers
 from main.utils_species import NoSpeciesFacade, HerbieFacade
 
 
@@ -258,6 +258,7 @@ class TestBulkGenericCreate(TestCase):
         """
         ds = self.ds_1
         url = reverse('api:dataset-data', kwargs={'pk': ds.pk})
+        # empty list is ok
         data = []
         client = self.custodian_1_client
         count = self.ds_1.record_queryset.count()
@@ -267,10 +268,11 @@ class TestBulkGenericCreate(TestCase):
         )
         self.assertEqual(self.ds_1.record_queryset.count(), count)
 
+        # but None is not
         data = None
         self.assertEqual(
             client.post(url, data, format='json').status_code,
-            status.HTTP_201_CREATED
+            status.HTTP_400_BAD_REQUEST
         )
         self.assertEqual(self.ds_1.record_queryset.count(), count)
 

--- a/biosys/apps/main/tests/api/test_dataset.py
+++ b/biosys/apps/main/tests/api/test_dataset.py
@@ -5,14 +5,13 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from main.models import Project, Site, Dataset
-from main.utils_auth import is_admin
-
 from main.tests.test_data_package import (
     clone,
     GENERIC_DATA_PACKAGE,
     LAT_LONG_OBSERVATION_DATA_PACKAGE,
     SPECIES_OBSERVATION_DATA_PACKAGE,
 )
+from main.utils_auth import is_admin
 
 
 class TestPermissions(TestCase):
@@ -248,6 +247,44 @@ class TestPermissions(TestCase):
                 )
                 self.assertTrue(Dataset.objects.count(), count - 1)
 
+    def test_options(self):
+        urls = [
+            reverse('api:dataset-list'),
+            reverse('api:dataset-detail', kwargs={'pk': 1})
+        ]
+        access = {
+            "forbidden": [self.anonymous_client],
+            "allowed": [self.readonly_client, self.custodian_1_client, self.custodian_2_client, self.admin_client]
+        }
+        for client in access['forbidden']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED
+                )
+        # authenticated
+        for client in access['allowed']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_200_OK
+                )
+
+    def test_options_model_choices(self):
+        """
+        Test that the options request return model choices for dataset type
+        :return:
+        """
+        url = reverse('api:dataset-list')
+        client = self.admin_client
+        resp = client.options(url)
+        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        data = resp.json()
+        choices = data.get('actions', {}).get('POST', {}).get('type', {}).get('choices', None)
+        self.assertTrue(choices)
+        expected = [{'value': d[0], 'display_name': d[1]} for d in Dataset.TYPE_CHOICES]
+        self.assertEquals(expected, choices)
+
 
 class TestDataPackageValidation(TestCase):
     """
@@ -430,5 +467,3 @@ class TestDataPackageValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-
-

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -235,6 +235,29 @@ class TestPermissions(TestCase):
                 )
                 self.assertTrue(Dataset.objects.count(), count - 1)
 
+    def test_options(self):
+        urls = [
+            reverse('api:genericRecord-list'),
+            reverse('api:genericRecord-detail', kwargs={'pk': 1})
+        ]
+        access = {
+            "forbidden": [self.anonymous_client],
+            "allowed": [self.readonly_client, self.custodian_1_client, self.custodian_2_client, self.admin_client]
+        }
+        for client in access['forbidden']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED
+                )
+        # authenticated
+        for client in access['allowed']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_200_OK
+                )
+
 
 class TestDataValidation(TestCase):
     fixtures = [

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -1,11 +1,10 @@
 import datetime
 
 from django.contrib.auth.models import User
+from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
 from django.utils import timezone
-from django.contrib.gis.geos import Point
-
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -243,6 +242,29 @@ class TestPermissions(TestCase):
                     status.HTTP_204_NO_CONTENT
                 )
                 self.assertTrue(Dataset.objects.count(), count - 1)
+
+    def test_options(self):
+        urls = [
+            reverse('api:observation-list'),
+            reverse('api:observation-detail', kwargs={'pk': 1})
+        ]
+        access = {
+            "forbidden": [self.anonymous_client],
+            "allowed": [self.readonly_client, self.custodian_1_client, self.custodian_2_client, self.admin_client]
+        }
+        for client in access['forbidden']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED
+                )
+        # authenticated
+        for client in access['allowed']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_200_OK
+                )
 
 
 class TestDataValidation(TestCase):

--- a/biosys/apps/main/tests/api/test_site.py
+++ b/biosys/apps/main/tests/api/test_site.py
@@ -261,3 +261,26 @@ class TestPermissions(TestCase):
                     status.HTTP_204_NO_CONTENT
                 )
                 self.assertTrue(Site.objects.count(), site_count - 1)
+
+    def test_options(self):
+        urls = [
+            reverse('api:site-list'),
+            reverse('api:site-detail', kwargs={'pk': 1})
+        ]
+        access = {
+            "forbidden": [self.anonymous_client],
+            "allowed": [self.readonly_client, self.custodian_1_client, self.custodian_2_client, self.admin_client]
+        }
+        for client in access['forbidden']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED
+                )
+        # authenticated
+        for client in access['allowed']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_200_OK
+                )

--- a/biosys/apps/main/tests/api/test_species_observation.py
+++ b/biosys/apps/main/tests/api/test_species_observation.py
@@ -1,19 +1,18 @@
 import datetime
 
 from django.contrib.auth.models import User
+from django.contrib.gis.geos import Point
 from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
 from django.utils import timezone
-from django.contrib.gis.geos import Point
-
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from main.models import Project, Site, Dataset
+from main.tests.api import helpers
 from main.tests.test_data_package import clone
 from main.utils_auth import is_admin
-from main.utils_species import HerbieFacade, NoSpeciesFacade
-from main.tests.api import helpers
+from main.utils_species import NoSpeciesFacade
 
 
 class TestPermissions(TestCase):
@@ -245,6 +244,29 @@ class TestPermissions(TestCase):
                     status.HTTP_204_NO_CONTENT
                 )
                 self.assertTrue(Dataset.objects.count(), count - 1)
+
+    def test_options(self):
+        urls = [
+            reverse('api:speciesObservation-list'),
+            reverse('api:speciesObservation-detail', kwargs={'pk': 1})
+        ]
+        access = {
+            "forbidden": [self.anonymous_client],
+            "allowed": [self.readonly_client, self.custodian_1_client, self.custodian_2_client, self.admin_client]
+        }
+        for client in access['forbidden']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_401_UNAUTHORIZED
+                )
+        # authenticated
+        for client in access['allowed']:
+            for url in urls:
+                self.assertEqual(
+                    client.options(url).status_code,
+                    status.HTTP_200_OK
+                )
 
 
 class TestDataValidation(TestCase):

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -132,6 +132,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
+    'DEFAULT_METADATA_CLASS': 'rest_framework.metadata.SimpleMetadata',
 }
 
 SWAGGER_SETTINGS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,14 +15,14 @@ requests==2.11
 Unipath==1.1
 
 # rest API
-djangorestframework>=3.4.5,<3.5
-coreapi>=2.0,<2.1
-django-filter>=0.14.0,<0.15.0
-django-crispy-forms==1.6.0
-django-rest-swagger==2.0.5,<3.0
-django-cors-headers==1.2.0
-dry-rest-permissions==0.1.6
-djangorestframework-gis==0.10.1
+djangorestframework>=3.5.3,<3.6
+coreapi>=2.1.1,<2.2
+django-filter>=1.0.1,<1.1.0
+django-crispy-forms>=1.6.1,<1.7.0
+django-rest-swagger>=2.1.0,<2.2.0
+django-cors-headers>=1.3.1,<1.4.0
+dry-rest-permissions>=0.1.8,<0.2
+djangorestframework-gis>=0.11,<0.12
 
 
 


### PR DESCRIPTION
* Contains #10 , merge it first
* Added the ability to query the model through with the http `options`  verb.  This query will get us the model choices.
* Some tests