### PR TITLE
Biosys 43 data validation

### DIFF
--- a/biosys/apps/main/api/helpers.py
+++ b/biosys/apps/main/api/helpers.py
@@ -1,0 +1,8 @@
+from django.utils import six
+
+
+def to_bool(s):
+    if isinstance(s, six.string_types):
+        return s.lower() in ('y', 'yes', 'true', 'on', '1')
+    else:
+        return bool(s)

--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -66,6 +66,9 @@ class SchemaValidator:
         self.strict = strict
 
     def __call__(self, data):
+        if not data:
+            msg = "cannot be null or empty"
+            raise ValidationError(('data', msg))
         if self.dataset is not None:
             validator = get_record_validator_for_dataset(self.dataset)
             validator.schema_error_as_warning = not self.strict
@@ -114,8 +117,8 @@ class GenericRecordSerializer(serializers.ModelSerializer):
         ]
     )
 
-    def __init__(self, **kwargs):
-        super(GenericRecordSerializer, self).__init__(**kwargs)
+    def __init__(self, instance=None, **kwargs):
+        super(GenericRecordSerializer, self).__init__(instance, **kwargs)
         strict = kwargs.get('context', {}).get('strict', False)
         schema_validator = SchemaValidator(strict=strict)
         self.fields['data'].validators = [schema_validator]

--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -68,7 +68,7 @@ class GenericDataValidator:
             validator.schema_error_as_warning = False
             result = validator.validate(data)
             if result.has_errors:
-                raise ValidationError(result.errors)
+                raise ValidationError(list(result.errors.items()))
 
     def set_context(self, serializer_field):
         ctx = serializer_field.parent.context

--- a/biosys/apps/main/api/urls.py
+++ b/biosys/apps/main/api/urls.py
@@ -13,6 +13,7 @@ router.register(r'datasets?', main_views.DatasetViewSet, 'dataset')
 router.register(r'generic_records?', main_views.GenericRecordViewSet, 'genericRecord')
 router.register(r'observations?', main_views.ObservationViewSet, 'observation')
 router.register(r'species_observations?', main_views.SpeciesObservationViewSet, 'speciesObservation')
+router.register(r'records?', main_views.RecordViewSet, 'records')
 
 url_patterns = [
     url(r'projects?/(?P<pk>\d+)/sites/?', main_views.ProjectSitesView.as_view(), name='project-sites'),  # bulk sites
@@ -24,7 +25,7 @@ url_patterns = [
     url(r'datasets?/(?P<pk>\d+)/upload-records/?', main_views.DatasetUploadRecordsView.as_view(),
         name='dataset-upload'),
     url(r'statistics/?', main_views.StatisticsView.as_view(), name="statistics"),
-    url(r'whoami/?', main_views.WhoamiView.as_view(), name="whoami")
+    url(r'whoami/?', main_views.WhoamiView.as_view(), name="whoami"),
 ]
 
 urls = router.urls + url_patterns

--- a/biosys/apps/main/api/urls.py
+++ b/biosys/apps/main/api/urls.py
@@ -13,7 +13,6 @@ router.register(r'datasets?', main_views.DatasetViewSet, 'dataset')
 router.register(r'generic_records?', main_views.GenericRecordViewSet, 'genericRecord')
 router.register(r'observations?', main_views.ObservationViewSet, 'observation')
 router.register(r'species_observations?', main_views.SpeciesObservationViewSet, 'speciesObservation')
-router.register(r'records?', main_views.RecordViewSet, 'records')
 
 url_patterns = [
     url(r'projects?/(?P<pk>\d+)/sites/?', main_views.ProjectSitesView.as_view(), name='project-sites'),  # bulk sites
@@ -25,7 +24,7 @@ url_patterns = [
     url(r'datasets?/(?P<pk>\d+)/upload-records/?', main_views.DatasetUploadRecordsView.as_view(),
         name='dataset-upload'),
     url(r'statistics/?', main_views.StatisticsView.as_view(), name="statistics"),
-    url(r'whoami/?', main_views.WhoamiView.as_view(), name="whoami"),
+    url(r'whoami/?', main_views.WhoamiView.as_view(), name="whoami")
 ]
 
 urls = router.urls + url_patterns

--- a/biosys/apps/main/api/validators.py
+++ b/biosys/apps/main/api/validators.py
@@ -57,7 +57,7 @@ class RecordValidatorResult:
         return result
 
 
-class GenericRecordValidator:
+class GenericRecordValidator(object):
     def __init__(self, dataset, schema_error_as_warning=True):
         self.schema = dataset.schema
         self.schema_error_as_warning = schema_error_as_warning

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -254,9 +254,6 @@ class GenericRecordViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filter_fields = ('id', 'site', 'dataset__id', 'dataset__name')
 
-    def __init__(self, **kwargs):
-        super(GenericRecordViewSet, self).__init__(**kwargs)
-
     def get_serializer_context(self):
         ctx = super(GenericRecordViewSet, self).get_serializer_context()
         ctx['strict'] = 'strict' in self.request.query_params

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
-from django.utils import six
 from dry_rest_permissions.generics import DRYPermissions
 from rest_framework import viewsets, filters, generics, status
 from rest_framework.parsers import MultiPartParser, FormParser
@@ -13,6 +12,7 @@ from rest_framework.views import APIView, Response
 
 from main import models
 from main.api import serializers
+from main.api.helpers import to_bool
 from main.api.uploaders import SiteUploader, FileReader, RecordCreator
 from main.api.validators import get_record_validator_for_dataset
 from main.models import Project, Site, Dataset, GenericRecord, Observation, SpeciesObservation
@@ -332,13 +332,6 @@ class WhoamiView(APIView):
         if request.user.is_authenticated():
             data = self.serializers(request.user).data
         return Response(data)
-
-
-def to_bool(s):
-    if isinstance(s, six.string_types):
-        return s.lower() in ('y', 'yes', 'true', 'on', '1')
-    else:
-        return bool(s)
 
 
 class DatasetUploadRecordsView(APIView):

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -254,6 +254,14 @@ class GenericRecordViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filter_fields = ('id', 'site', 'dataset__id', 'dataset__name')
 
+    def __init__(self, **kwargs):
+        super(GenericRecordViewSet, self).__init__(**kwargs)
+
+    def get_serializer_context(self):
+        ctx = super(GenericRecordViewSet, self).get_serializer_context()
+        ctx['strict'] = 'strict' in self.request.query_params
+        return ctx
+
 
 class ObservationViewSet(GenericRecordViewSet):
     queryset = models.Observation.objects.all()
@@ -376,46 +384,3 @@ class DatasetUploadRecordsView(APIView):
             data.append(result)
         status_code = status.HTTP_200_OK if not has_error else status.HTTP_400_BAD_REQUEST
         return Response(data, status=status_code)
-
-
-class RecordViewSet(viewsets.GenericViewSet):
-    def __init__(self, **kwargs):
-        super(RecordViewSet, self).__init__(**kwargs)
-        print('__init__', kwargs)
-        self.dataset = None
-
-    def list(self, request):
-        return Response(data="Not implemented")
-
-    def create(self, request):
-        return Response(data="Not implemented")
-
-    def retrieve(self, request, pk=None):
-        return Response(data="Not implemented")
-
-    def update(self, request, pk=None):
-        return Response(data="Not implemented")
-
-    def partial_update(self, request, pk=None):
-        return Response(data="Not implemented")
-
-    def destroy(self, request, pk=None):
-        return Response(data="Not implemented")
-
-    def dispatch(self, request, *args, **kwargs):
-        print('dispatch', self, request, *args, **kwargs)
-        return super(RecordViewSet, self).dispatch(request, *args, **kwargs)
-
-    def get_serializer_context(self):
-        print('get_serializer')
-        result = super(RecordViewSet, self).get_serializer_context()
-        print('get_serializer', result)
-        return result
-
-    def get_queryset(self):
-        print('get_queryset')
-        return GenericRecord.objects.all()
-
-    def get_serializer(self):
-        print('get_serializer')
-        return serializers.GenericRecordSerializer()

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -376,3 +376,46 @@ class DatasetUploadRecordsView(APIView):
             data.append(result)
         status_code = status.HTTP_200_OK if not has_error else status.HTTP_400_BAD_REQUEST
         return Response(data, status=status_code)
+
+
+class RecordViewSet(viewsets.GenericViewSet):
+    def __init__(self, **kwargs):
+        super(RecordViewSet, self).__init__(**kwargs)
+        print('__init__', kwargs)
+        self.dataset = None
+
+    def list(self, request):
+        return Response(data="Not implemented")
+
+    def create(self, request):
+        return Response(data="Not implemented")
+
+    def retrieve(self, request, pk=None):
+        return Response(data="Not implemented")
+
+    def update(self, request, pk=None):
+        return Response(data="Not implemented")
+
+    def partial_update(self, request, pk=None):
+        return Response(data="Not implemented")
+
+    def destroy(self, request, pk=None):
+        return Response(data="Not implemented")
+
+    def dispatch(self, request, *args, **kwargs):
+        print('dispatch', self, request, *args, **kwargs)
+        return super(RecordViewSet, self).dispatch(request, *args, **kwargs)
+
+    def get_serializer_context(self):
+        print('get_serializer')
+        result = super(RecordViewSet, self).get_serializer_context()
+        print('get_serializer', result)
+        return result
+
+    def get_queryset(self):
+        print('get_queryset')
+        return GenericRecord.objects.all()
+
+    def get_serializer(self):
+        print('get_serializer')
+        return serializers.GenericRecordSerializer()

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
+from django.utils import six
 from dry_rest_permissions.generics import DRYPermissions
 from rest_framework import viewsets, filters, generics, status
 from rest_framework.parsers import MultiPartParser, FormParser
@@ -333,6 +334,13 @@ class WhoamiView(APIView):
         return Response(data)
 
 
+def to_bool(s):
+    if isinstance(s, six.string_types):
+        return s.lower() in ('y', 'yes', 'true', 'on', '1')
+    else:
+        return bool(s)
+
+
 class DatasetUploadRecordsView(APIView):
     """
     Upload file for records (xlsx, csv)
@@ -351,9 +359,9 @@ class DatasetUploadRecordsView(APIView):
 
     def post(self, request, *args, **kwargs):
         file_obj = request.data['file']
-        create_site = 'create_site' in request.data and bool(request.data['create_site'])
-        delete_previous = 'delete_previous' in request.data and bool(request.data['delete_previous'])
-        strict = 'strict' in request.data and bool(request.data['strict'])
+        create_site = 'create_site' in request.data and to_bool(request.data['create_site'])
+        delete_previous = 'delete_previous' in request.data and to_bool(request.data['delete_previous'])
+        strict = 'strict' in request.data and to_bool(request.data['strict'])
 
         if file_obj.content_type not in FileReader.SUPPORTED_TYPES:
             msg = "Wrong file type {}. Should be one of: {}".format(file_obj.content_type, SiteUploader.SUPPORTED_TYPES)

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -135,19 +135,6 @@ class Dataset(models.Model):
                         resource.get('name'),
                         e))
 
-    def validate_data(self, data):
-        if not data:
-            msg = "field 'data' cannot be null or empty"
-            raise ValidationError(msg)
-        try:
-            field_errors = self.schema.get_error_fields(data)
-            if len(field_errors) > 0:
-                for field_name, data in field_errors:
-                    msg = "'{}': {}".format(field_name, data.get('error'))
-                    raise ValidationError(msg)
-        except Exception as e:
-            raise ValidationError(e)
-
     def clean(self):
         """
         Validate the data descriptor
@@ -295,9 +282,6 @@ class AbstractRecord(models.Model):
 
     def has_object_destroy_permission(self, request):
         return is_admin(request.user) or self.is_custodian(request.user)
-
-    def clean(self):
-        self.dataset.validate_data(self.data)
 
     class Meta:
         abstract = True

--- a/biosys/apps/main/tests/api/helpers.py
+++ b/biosys/apps/main/tests/api/helpers.py
@@ -228,3 +228,7 @@ def create_data_package_from_fields(fields):
     result = clone(GENERIC_DATA_PACKAGE)
     result['resources'][0]['schema']['fields'] = fields
     return result
+
+
+def set_strict_mode(url):
+    return url + '?strict'

--- a/biosys/apps/main/tests/api/test_auth.py
+++ b/biosys/apps/main/tests/api/test_auth.py
@@ -20,7 +20,7 @@ class TestBasicAuth(TestCase):
         client = APIClient()
         url = reverse('api:dataset-list')
         resp = client.get(url)
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
         user = User.objects.filter(username="readonly").first()
         self.assertIsNotNone(user)
@@ -72,7 +72,7 @@ class TestBasicAuth(TestCase):
         # can't get dataset list without token
         url = reverse('api:dataset-list')
         resp = client.get(url)
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
 
         # set credential token
         client.credentials(HTTP_AUTHORIZATION='Token ' + token)

--- a/biosys/apps/main/tests/api/test_datapackage_data.py
+++ b/biosys/apps/main/tests/api/test_datapackage_data.py
@@ -80,9 +80,9 @@ class TestGenericPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:
@@ -483,9 +483,9 @@ class TestObservationPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:
@@ -861,9 +861,9 @@ class TestSpeciesObservationPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:

--- a/biosys/apps/main/tests/api/test_dataset.py
+++ b/biosys/apps/main/tests/api/test_dataset.py
@@ -87,9 +87,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -259,9 +259,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:

--- a/biosys/apps/main/tests/api/test_explorer.py
+++ b/biosys/apps/main/tests/api/test_explorer.py
@@ -51,4 +51,4 @@ class TestView(TestCase):
     def test_anonymous_forbidden(self):
         url = reverse('api:explorer')
         resp = self.anonymous_client.get(url, follow=True)
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(resp.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -88,7 +88,7 @@ class TestPermissions(TestCase):
         for client in access['forbidden']:
             for url in urls:
                 self.assertIn(
-                    client.options(url).status_code,
+                    client.get(url).status_code,
                     [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -87,9 +87,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
-                    client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                self.assertIn(
+                    client.options(url).status_code,
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:
@@ -247,9 +247,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -325,6 +325,8 @@ class TestDataValidation(TestCase):
             "data": {}
         }
         url = reverse('api:genericRecord-list')
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = GenericRecord.objects.count()
         self.assertEqual(
@@ -346,6 +348,8 @@ class TestDataValidation(TestCase):
             "data": incorrect_data
         }
         url = reverse('api:genericRecord-list')
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = GenericRecord.objects.count()
         self.assertEqual(
@@ -367,6 +371,8 @@ class TestDataValidation(TestCase):
             "data": incorrect_data
         }
         url = reverse('api:genericRecord-detail', kwargs={"pk": record.pk})
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = GenericRecord.objects.count()
         self.assertEqual(

--- a/biosys/apps/main/tests/api/test_misc.py
+++ b/biosys/apps/main/tests/api/test_misc.py
@@ -15,9 +15,9 @@ class TestWhoAmI(TestCase):
     def test_get(self):
         anonymous = APIClient()
         client = anonymous
-        self.assertEqual(
+        self.assertIn(
             client.get(self.url).status_code,
-            status.HTTP_401_UNAUTHORIZED
+            [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
         )
 
         user = G(get_user_model())
@@ -68,9 +68,9 @@ class TestStatistics(TestCase):
     def test_get(self):
         anonymous = APIClient()
         client = anonymous
-        self.assertEqual(
+        self.assertIn(
             client.get(self.url).status_code,
-            status.HTTP_401_UNAUTHORIZED
+            [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
         )
 
         user = G(get_user_model())

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -91,9 +91,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:
@@ -255,9 +255,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -378,6 +378,8 @@ class TestDataValidation(TestCase):
             "data": incorrect_data
         }
         url = reverse('api:observation-list')
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = ds.record_queryset.count()
         self.assertEqual(
@@ -402,6 +404,8 @@ class TestDataValidation(TestCase):
         url = reverse('api:observation-detail', kwargs={"pk": record.pk})
         client = self.custodian_1_client
         count = ds.record_queryset.count()
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         self.assertEqual(
             client.put(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST

--- a/biosys/apps/main/tests/api/test_project.py
+++ b/biosys/apps/main/tests/api/test_project.py
@@ -78,9 +78,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -268,9 +268,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:

--- a/biosys/apps/main/tests/api/test_records_upload.py
+++ b/biosys/apps/main/tests/api/test_records_upload.py
@@ -78,9 +78,9 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             }
             resp = client.post(self.url, data=data, format='multipart')
             self.assertEquals(status.HTTP_200_OK, resp.status_code)
-            qs = self.ds.record_queryset
+            # The records should be saved in order of the row
+            qs = self.ds.record_queryset.order_by('id')
             self.assertEquals(len(csv_data) - 1, qs.count())
-
             expected_data = {
                 'Column A': 'A1',
                 'Column B': 'B1',

--- a/biosys/apps/main/tests/api/test_site.py
+++ b/biosys/apps/main/tests/api/test_site.py
@@ -78,9 +78,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -274,9 +274,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:

--- a/biosys/apps/main/tests/api/test_species_observation.py
+++ b/biosys/apps/main/tests/api/test_species_observation.py
@@ -95,9 +95,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         for client in access['allowed']:
             for url in urls:
@@ -256,9 +256,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -383,6 +383,8 @@ class TestDataValidation(TestCase):
             "data": incorrect_data
         }
         url = reverse('api:speciesObservation-list')
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = ds.record_queryset.count()
         self.assertEqual(
@@ -405,6 +407,8 @@ class TestDataValidation(TestCase):
             "data": incorrect_data
         }
         url = reverse('api:speciesObservation-detail', kwargs={"pk": record.pk})
+        # set strict mode
+        url = helpers.set_strict_mode(url)
         client = self.custodian_1_client
         count = ds.record_queryset.count()
         self.assertEqual(

--- a/biosys/apps/main/tests/api/test_user.py
+++ b/biosys/apps/main/tests/api/test_user.py
@@ -75,9 +75,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.get(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:
@@ -226,9 +226,9 @@ class TestPermissions(TestCase):
         }
         for client in access['forbidden']:
             for url in urls:
-                self.assertEqual(
+                self.assertIn(
                     client.options(url).status_code,
-                    status.HTTP_401_UNAUTHORIZED
+                    [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
                 )
         # authenticated
         for client in access['allowed']:

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -36,7 +36,7 @@ if not DEBUG:
 # Application definition
 # The variables below are added to all responses in biosys/context_processors.py
 SITE_TITLE = 'BioSys - WA Biological Survey Database'
-APPLICATION_VERSION_NO = '3.0.b1'
+APPLICATION_VERSION_NO = '3.1.0'
 
 INSTALLED_APPS = (
     'grappelli',  # Must be before django.contrib.admin


### PR DESCRIPTION
* The DRF model serializers for `GenericRecord`, `Observation` and `SpeciesObservations`, now use the same schema validator that the one used when importing data through files. By default it is set to be 'soft' (not strict) which means that it let pass everything. To activate the strict mode just add the param `?strict` in  your query.
* Modified the tests to run in strict mode
* Modified test to accommodate 403 response from api. Since the new custom session authentication the api returns 403 instead of 401 for unauthorised action (???) 
* Bumped version to 3.1.0