### PR TITLE
Custodians mandatory

### DIFF
--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -16,7 +16,7 @@ from main.models import Project, Site, Dataset, Record
 class SimpleUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = get_user_model()
-        fields = ('id', 'username', 'first_name', 'last_name', 'email')
+        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'is_superuser', 'is_staff')
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -76,7 +76,7 @@ class Project(models.Model):
 
     @staticmethod
     def has_create_permission(request):
-        return is_admin(request.user)
+        return True
 
     @staticmethod
     def has_update_permission(request):

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -53,7 +53,7 @@ class Project(models.Model):
                                   help_text='Define here the attributes that all your sites will share. '
                                             'This allows validation when importing sites.')
 
-    custodians = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True,
+    custodians = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=False,
                                         help_text="Users that have write/upload access to the data of this project.")
 
     def is_custodian(self, user):


### PR DESCRIPTION
* Made custodian mandatory
* Added is_superuser and is_staff in /whoami response
* Relaxed the project creation authorisation to every authenticated user
* Modified tests accordingly.