### PR TITLE
Changing unauthenticated response from 403 to 401

### DIFF
--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -586,7 +586,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_excel_type(self):
         schema_fields = [

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -2045,4 +2045,4 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/biosys/apps/main/tests/api/test_species_observation.py
+++ b/biosys/apps/main/tests/api/test_species_observation.py
@@ -1021,7 +1021,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestSpeciesNameFromNameID(helpers.BaseUserTestCase):

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -115,9 +115,9 @@ LOGIN_REDIRECT_URL = '/'
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'main.api.authentication.NoCsrfSessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.BasicAuthentication',
+        'main.api.authentication.NoCsrfSessionAuthentication',
     ],
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.


### PR DESCRIPTION
Changing the order of the DRF authentication classes settings seems to fix the problem of being unauthenticated returning 403 instead of 401