### PR TITLE
Removed trailing and heading spaces when extracting species_name

### DIFF
--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -1153,3 +1153,66 @@ class TestSpeciesObservationSchemaCast(TestCase):
         }
         schema = SpeciesObservationSchema(descriptor)
         self.assertEqual(species_name, schema.cast_species_name(record))
+
+    def test_space_stripping(self):
+        """
+        The cast should strip leading and trailing spaces
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        species_name = 'Chubby Bat'
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': '  Chubby Bat  '
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        self.assertEqual(species_name, schema.cast_species_name(record))
+
+    def test_blank(self):
+        """
+        Blank should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': ''
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)
+
+    def test_none(self):
+        """
+        Blank should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': None
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)
+
+    def test_nimber(self):
+        """
+        Blank should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': 1234
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)

--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -1201,7 +1201,7 @@ class TestSpeciesObservationSchemaCast(TestCase):
         with self.assertRaises(Exception):
             schema.cast_species_name(record)
 
-    def test_nimber(self):
+    def test_number(self):
         """
         Blank should raise an exception
         :return:

--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -1171,7 +1171,7 @@ class TestSpeciesObservationSchemaCast(TestCase):
 
     def test_blank(self):
         """
-        Blank should raise an exception
+        Blank string should raise an exception
         :return:
         """
         descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
@@ -1179,7 +1179,7 @@ class TestSpeciesObservationSchemaCast(TestCase):
             'Observation Date': "18/08/2016",
             'Latitude': -32,
             'Longitude': 115,
-            'Species Name': ''
+            'Species Name': '   '
         }
         schema = SpeciesObservationSchema(descriptor)
         with self.assertRaises(Exception):
@@ -1187,7 +1187,7 @@ class TestSpeciesObservationSchemaCast(TestCase):
 
     def test_none(self):
         """
-        Blank should raise an exception
+        None should raise an exception
         :return:
         """
         descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
@@ -1203,7 +1203,7 @@ class TestSpeciesObservationSchemaCast(TestCase):
 
     def test_number(self):
         """
-        Blank should raise an exception
+        Number should raise an exception
         :return:
         """
         descriptor = clone(SPECIES_OBSERVATION_SCHEMA)

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -294,7 +294,7 @@ class SchemaField:
         # TODO: remove that when running in Python3
         if isinstance(value, six.string_types) and not isinstance(value, six.text_type):
             # the StringType accepts only unicode
-            value = six.u(value)
+            value = six.u(value).strip()
         return self.type.cast(value)
 
     def validation_error(self, value):
@@ -735,10 +735,7 @@ class SpeciesObservationSchema(ObservationSchema):
 
     def cast_species_name(self, record):
         field = self.species_name_field
-        value = field.cast(record.get(field.name)) if field is not None else None
-        if value and isinstance(value, six.string_types):
-            value = value.strip()
-        return value
+        return field.cast(record.get(field.name)) if field is not None else None
 
     def cast_species_name_id(self, record):
         field = self.species_name_id_field

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -735,7 +735,10 @@ class SpeciesObservationSchema(ObservationSchema):
 
     def cast_species_name(self, record):
         field = self.species_name_field
-        return field.cast(record.get(field.name)) if field is not None else None
+        value = field.cast(record.get(field.name)) if field is not None else None
+        if value and isinstance(value, six.string_types):
+            value = value.strip()
+        return value
 
     def cast_species_name_id(self, record):
         field = self.species_name_id_field

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -291,10 +291,12 @@ class SchemaField:
         :param value:
         :return:
         """
-        # TODO: remove that when running in Python3
-        if isinstance(value, six.string_types) and not isinstance(value, six.text_type):
-            # the StringType accepts only unicode
-            value = six.u(value).strip()
+        if isinstance(value, six.string_types):
+            value = value.strip()
+            # TODO: remove that when running in Python3
+            if not isinstance(value, six.text_type):
+                # the StringType accepts only unicode
+                value = six.u(value).strip()
         return self.type.cast(value)
 
     def validation_error(self, value):


### PR DESCRIPTION
Put the string stripping at the top level. Every string will be stripped. This allows to raise a schema error if the user passes a blank string for a required field.