### PR TITLE
Biosys 71 schema inference

### DIFF
--- a/biosys/apps/main/api/uploaders.py
+++ b/biosys/apps/main/api/uploaders.py
@@ -12,7 +12,7 @@ from openpyxl import load_workbook
 from main.api.validators import get_record_validator_for_dataset
 from main.constants import MODEL_SRID
 from main.models import Site, Dataset
-from main.utils_data_package import GeometryParser, ObservationSchema, SpeciesObservationSchema
+from main.utils_data_package import GeometryParser, ObservationSchema, SpeciesObservationSchema, BiosysSchema
 from main.utils_misc import get_value
 from main.utils_species import HerbieFacade, get_key_for_value
 
@@ -298,6 +298,12 @@ class DataPackageBuilder:
         constraints['required'] = required
         field['constraints'] = constraints
 
+    @staticmethod
+    def set_biosys_type(field, type_):
+        biosys_tag = field.get(BiosysSchema.BIOSYS_KEY_NAME, {})
+        biosys_tag['type'] = type_
+        field[BiosysSchema.BIOSYS_KEY_NAME] = biosys_tag
+
     def __init__(self, descriptor=None, title=None, **kwargs):
         descriptor = descriptor or {}
         if title:
@@ -382,6 +388,7 @@ class DataPackageBuilder:
         - Fields of type 'date' or 'datetime' should have format = 'any' instead of default
           (the 'any' makes the date parser more flexible)
         - If it contains a latitude/longitude schema set the lat/long columns type='number' with constraint required
+          and they should be tagged with the correct biosys tag.
         """
         for field in self.fields:
             type_ = field.get('type')
@@ -405,6 +412,8 @@ class DataPackageBuilder:
                 self.set_type('number', lon_field)
                 self.set_required(lat_field)
                 self.set_required(lon_field)
+                self.set_biosys_type(lat_field, BiosysSchema.LATITUDE_TYPE_NAME)
+                self.set_biosys_type(lon_field, BiosysSchema.LONGITUDE_TYPE_NAME)
             else:
                 # more that one lat or long fields? Should not happen.
                 pass

--- a/biosys/apps/main/api/uploaders.py
+++ b/biosys/apps/main/api/uploaders.py
@@ -4,10 +4,13 @@ import datetime
 from os import path
 
 import datapackage
+from openpyxl import load_workbook
+
 from django.conf import settings
 from django.utils import six, timezone
 from django.utils.text import slugify
-from openpyxl import load_workbook
+from django.core.exceptions import ValidationError
+
 
 from main.api.validators import get_record_validator_for_dataset
 from main.constants import MODEL_SRID
@@ -416,6 +419,7 @@ class DataPackageBuilder:
                 self.set_biosys_type(lon_field, BiosysSchema.LONGITUDE_TYPE_NAME)
             else:
                 # more that one lat or long fields? Should not happen.
-                pass
-
+                # The GeometryParser should detect the error anf return False to is_lat_long().
+                e = ValidationError("Two or more Latitude or Longitude columns.")
+                self.biosys_errors.append(e)
         self.package.commit()

--- a/biosys/apps/main/api/uploaders.py
+++ b/biosys/apps/main/api/uploaders.py
@@ -336,7 +336,7 @@ class DataPackageBuilder:
     def infer_biosys_type(self):
         """
         Use the schema models in utils to infer the type.
-        The constructor should throw an exception if something is not correc
+        The constructor should throw an exception if something is not correct
         :return:
         """
         # TODO: use a better control workflow than exception

--- a/biosys/apps/main/tests/api/test_schema_inference.py
+++ b/biosys/apps/main/tests/api/test_schema_inference.py
@@ -132,7 +132,7 @@ class TestGenericSchema(InferTestBase):
             columns,
             ['Something', '2018-01-19'],
             ['Another thing', dt.date(2017, 12, 29).isoformat()],
-            ['Another thing', dt.date(2017, 8, 1).isoformat()]
+            ['Another thing', '2017-08-01']
         ]
         client = self.custodian_1_client
         file_ = helpers.rows_to_xlsx_file(rows)
@@ -162,8 +162,8 @@ class TestGenericSchema(InferTestBase):
 
     def test_observation_with_lat_long(self):
         """
-        Scenario:
-         Given that a column named latitude and longitude exists
+        Scenario: File with column Latitude and Longitude
+         Given that a column named Latitude and Longitude exists
          Then they should be of type 'number'
          And they should be set as required
          And they should be tagged with the appropriate biosys tag

--- a/biosys/apps/main/tests/api/test_schema_inference.py
+++ b/biosys/apps/main/tests/api/test_schema_inference.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from main.tests.api import helpers
 from main.models import Dataset
 from main import utils_data_package
+from main.utils_data_package import BiosysSchema
 
 
 class InferTestBase(helpers.BaseUserTestCase):
@@ -165,6 +166,7 @@ class TestGenericSchema(InferTestBase):
          Given that a column named latitude and longitude exists
          Then they should be of type 'number'
          And they should be set as required
+         And they should be tagged with the appropriate biosys tag
          And the dataset type should be observation
         """
         columns = ['What', 'Latitude', 'Longitude']
@@ -194,6 +196,9 @@ class TestGenericSchema(InferTestBase):
             self.assertEquals(lon_field.type, 'number')
             self.assertTrue(lat_field.required)
             self.assertTrue(lon_field.required)
+            # biosys types
+            self.assertTrue(BiosysSchema(lat_field.get(BiosysSchema.BIOSYS_KEY_NAME)).is_latitude())
+            self.assertTrue(BiosysSchema(lon_field.get(BiosysSchema.BIOSYS_KEY_NAME)).is_longitude())
 
             self.assertEquals(Dataset.TYPE_OBSERVATION, received.get('type'))
             # test biosys validity

--- a/biosys/apps/main/tests/api/test_schema_inference.py
+++ b/biosys/apps/main/tests/api/test_schema_inference.py
@@ -1,17 +1,14 @@
-import json
-from os import path
 import datetime as dt
+from os import path
 
-from dateutil.parser import parse as dt_parse
 from datapackage import Package
+from django.core.exceptions import ValidationError
 from django.shortcuts import reverse
 from rest_framework import status
 
-from django.core.exceptions import ValidationError
-
-from main.tests.api import helpers
-from main.models import Dataset
 from main import utils_data_package
+from main.models import Dataset
+from main.tests.api import helpers
 from main.utils_data_package import BiosysSchema
 
 
@@ -100,22 +97,22 @@ class TestGenericSchema(InferTestBase):
             self.assertEquals(len(schema.fields), len(columns))
             self.assertEquals(schema.field_names, columns)
 
-            field = schema.get_field_by_mame('Name')
+            field = schema.get_field_by_name('Name')
             self.assertEquals(field.type, 'string')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'default')
 
-            field = schema.get_field_by_mame('Age')
+            field = schema.get_field_by_name('Age')
             self.assertEquals(field.type, 'integer')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'default')
 
-            field = schema.get_field_by_mame('Weight')
+            field = schema.get_field_by_name('Weight')
             self.assertEquals(field.type, 'number')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'default')
 
-            field = schema.get_field_by_mame('Comments')
+            field = schema.get_field_by_name('Comments')
             self.assertEquals(field.type, 'string')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'default')
@@ -150,12 +147,12 @@ class TestGenericSchema(InferTestBase):
             # verify schema
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
-            field = schema.get_field_by_mame('What')
+            field = schema.get_field_by_name('What')
             self.assertEquals(field.type, 'string')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'default')
 
-            field = schema.get_field_by_mame('When')
+            field = schema.get_field_by_name('When')
             self.assertEquals(field.type, 'date')
             self.assertFalse(field.required)
             self.assertEquals(field.format, 'any')
@@ -190,8 +187,8 @@ class TestGenericSchema(InferTestBase):
             # verify fields attributes
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
-            lat_field = schema.get_field_by_mame('Latitude')
-            lon_field = schema.get_field_by_mame('Longitude')
+            lat_field = schema.get_field_by_name('Latitude')
+            lon_field = schema.get_field_by_name('Longitude')
             self.assertEquals(lat_field.type, 'number')
             self.assertEquals(lon_field.type, 'number')
             self.assertTrue(lat_field.required)

--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -1025,7 +1025,7 @@ class TestSpeciesObservationSchema(TestCase):
             SpeciesObservationSchema.find_species_name_field_or_throws(descriptor)
 
         # add biosys type
-        field_desc['biosys'] = {
+        field_desc[BiosysSchema.BIOSYS_KEY_NAME] = {
             'type': 'speciesName'
         }
         descriptor = clone(LAT_LONG_OBSERVATION_SCHEMA)

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -128,6 +128,7 @@ class BiosysSchema:
               }
     }
     """
+    BIOSYS_KEY_NAME = 'biosys'
     OBSERVATION_DATE_TYPE_NAME = 'observationDate'
     LATITUDE_TYPE_NAME = 'latitude'
     LONGITUDE_TYPE_NAME = 'longitude'
@@ -204,7 +205,7 @@ class SchemaField:
         # the tableschema field.
         self.tableschema_field = TableField(self.descriptor)
         # biosys specific
-        self.biosys = BiosysSchema(self.descriptor.get('biosys'))
+        self.biosys = BiosysSchema(self.descriptor.get(BiosysSchema.BIOSYS_KEY_NAME))
         self.constraints = SchemaConstraints(self.descriptor.get('constraints', {}))
 
     # implement some dict like methods

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -912,7 +912,7 @@ class GeometryParser(object):
                 self.errors.append(format_required_message(self.northing_field))
 
     def is_valid(self):
-        return not self.errors
+        return not bool(self.errors)
 
     @property
     def is_easting_northing(self):

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -451,14 +451,14 @@ class GenericSchema(object):
     def required_fields(self):
         return [f for f in self.fields if f.required]
 
-    def get_field_by_mame(self, name):
+    def get_field_by_name(self, name):
         for f in self.fields:
             if f.name == name:
                 return f
         return None
 
     def field_validation_error(self, field_name, value):
-        field = self.get_field_by_mame(field_name)
+        field = self.get_field_by_name(field_name)
         if field is not None:
             return field.validation_error(value)
         else:
@@ -1077,7 +1077,7 @@ class GeometryParser(object):
             return site_code_field, errors
         if site_code_field is None:
             site_code_fk = self.schema.get_fk_for_model_field('Site', 'code')
-            site_code_field = self.schema.get_field_by_mame(site_code_fk.data_field) if site_code_fk else None
+            site_code_field = self.schema.get_field_by_name(site_code_fk.data_field) if site_code_fk else None
         return site_code_field, None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ Unipath==1.1
 six==1.10
 python-dateutil==2.6.0
 future==0.16.0
-python-slugify==1.2.4
 
 # frictionless datapackage and tableschema
 datapackage>=1.0,<2.0


### PR DESCRIPTION
* Added the lat/long scenario:
```
     Scenario: file with column Latitude and Longitude
         Given that a column named Latitude and Longitude exists
         Then they should be of type 'number'
         And they should be set as required
         And they should be tagged with the appropriate biosys tag
         And the dataset type should be observation
```
* And the less important 'yyyy-mm-dd' date as string case:
```
     Scenario: date column with ISO string 'yyyy-mm-dd'
        Given that a column is provided with strings of form 'yyyy-mm-dd'
        Then the column type should be 'date'
        And the format should be 'any'

```
* Remove python-slugify dependency