### PR TITLE
Fix Record query slow for species observations

### DIFF
--- a/biosys/apps/main/api/validators.py
+++ b/biosys/apps/main/api/validators.py
@@ -159,7 +159,7 @@ class SpeciesObservationValidator(ObservationValidator):
         super(SpeciesObservationValidator, self).__init__(dataset, schema_error_as_warning)
         self.species_name_col = self.schema.species_name_field.name if self.schema.species_name_field else None
         self.species_name_id_col = self.schema.species_name_id_field.name if self.schema.species_name_id_field else None
-        self.species_mapping = kwargs.get('species_mapping')
+        self.species_name_id_mapping = kwargs.get('species_name_id_mapping')
 
     def validate(self, data, schema_error_as_warning=True):
         result = super(SpeciesObservationValidator, self).validate(data)
@@ -178,8 +178,8 @@ class SpeciesObservationValidator(ObservationValidator):
     def validate_species(self, data):
         result = RecordValidatorResult()
         name_id = self.schema.cast_species_name_id(data)
-        if name_id and self.species_mapping is not None:
-            if name_id not in self.species_mapping.values():
+        if name_id and self.species_name_id_mapping is not None:
+            if name_id not in self.species_name_id_mapping.values():
                 message = "Cannot find a species with nameId={}".format(name_id)
                 result.add_column_error(self.species_name_id_col, message)
         return result

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -271,8 +271,8 @@ class DatasetRecordsView(generics.ListAPIView, generics.DestroyAPIView, SpeciesM
         ctx = super(DatasetRecordsView, self).get_serializer_context()
         if self.dataset:
             ctx['dataset'] = self.dataset
-            if self.dataset.type == Dataset.TYPE_SPECIES_OBSERVATION and 'species_mapping' not in ctx:
-                ctx['species_mapping'] = self.species_facade_class().name_id_by_species_name()
+            if self.dataset.type == Dataset.TYPE_SPECIES_OBSERVATION and 'species_naming_facade_class' not in ctx:
+                ctx['species_naming_facade_class'] = self.species_facade_class
         return ctx
 
     def search_data(self, qs, search_param, order_by=None):
@@ -394,9 +394,7 @@ class RecordViewSet(viewsets.ModelViewSet, SpeciesMixin):
         ctx['dataset'] = self.dataset
         ctx['strict'] = self.strict
         if self.dataset and self.dataset.type == Dataset.TYPE_SPECIES_OBSERVATION:
-            # set the species map for name id lookup
-            if 'species_mapping' not in ctx:
-                ctx['species_mapping'] = self.species_facade_class().name_id_by_species_name()
+            ctx['species_naming_facade_class'] = self.species_facade_class
         return ctx
 
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
The problem was that the `RecordSerializer` was loading a `name_id` -> `species_name` mapping from herbie every time if was used with a Species Observation dataset. This mapping was loaded even for a deserialisation (!) hence the delay for any get.
Now this mapping (used for name_id extraction/validation) should be used/loaded only for post/put/patch. 