### PR TITLE
Various fixes

### DIFF
--- a/biosys/apps/main/api/uploaders.py
+++ b/biosys/apps/main/api/uploaders.py
@@ -34,15 +34,18 @@ def xlsx_to_csv(file_):
     output = six.StringIO()
     writer = csv.writer(output)
     wb = load_workbook(filename=file_, read_only=True)
-    ws = wb.active
-    for row in ws.rows:
-        r = [_format(cell) for cell in row]
-        writer.writerow(r)
+    # use the first sheet
+    if len(wb.worksheets) > 0:
+        ws = wb.worksheets[0]
+        for row in ws.rows:
+            r = [_format(cell) for cell in row]
+            writer.writerow(r)
     # rewind
     output.seek(0)
     return output
 
 
+# TODO: investigate the use frictionless tabulator.Stream as a xlsx/csv reader instead of this class
 class FileReader(object):
     """
     Accept a csv or a xlsx as file and provide a row generator.

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -115,9 +115,13 @@ class ProjectSitesView(generics.ListCreateAPIView, generics.DestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         site_ids = request.data
-        if not site_ids and not isinstance(site_ids, list):
-            return Response("A list of site ids must be provided", status=status.HTTP_400_BAD_REQUEST)
-        Site.objects.filter(project=self.project, id__in=site_ids).delete()
+        if isinstance(site_ids, list):
+            qs = Site.objects.filter(project=self.project, id__in=site_ids)
+        elif site_ids == 'all':
+            qs = Site.objects.filter(project=self.project)
+        else:
+            return Response("A list of site ids must be provided or 'all'", status=status.HTTP_400_BAD_REQUEST)
+        qs.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
* When uploading record from a multi-sheet file, the uploader use the first sheet instead of the active one to be consistent with the inferer.
https://decbugs.com/view.php?id=6859

*Added the 'all' parameters in the DELETE project/{pk}/sites request to delete all sites from a project.