### PR TITLE
Fix deprecation warnings

### DIFF
--- a/biosys/apps/main/api/urls.py
+++ b/biosys/apps/main/api/urls.py
@@ -38,4 +38,5 @@ url_patterns = [
     url(r'utils/infer-dataset/?', api_views.InferDatasetView.as_view(), name='infer-dataset')
 ]
 
+app_name = 'api'
 urls = router.urls + url_patterns

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -442,7 +442,7 @@ class WhoamiView(APIView):
 
     def get(self, request, **kwargs):
         data = {}
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             data = self.serializers(request.user).data
         return Response(data)
 

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -125,7 +125,8 @@ class Project(models.Model):
 @python_2_unicode_compatible
 class Site(models.Model):
     project = models.ForeignKey('Project', null=False, blank=False,
-                                verbose_name="Project", help_text="Select the project this site is part of (required)")
+                                verbose_name="Project", help_text="Select the project this site is part of (required)",
+                                on_delete=models.CASCADE)
     name = models.CharField(max_length=150, blank=True,
                             verbose_name="Name",
                             help_text="Enter a more descriptive name for this site, if one exists.")
@@ -214,7 +215,7 @@ class Dataset(models.Model):
         (TYPE_SPECIES_OBSERVATION, 'Species observation')
     ]
     project = models.ForeignKey('Project', null=False, blank=False, related_name='projects',
-                                related_query_name='project')
+                                related_query_name='project', on_delete=models.CASCADE)
     name = models.CharField(max_length=200, null=False, blank=False)
     code = models.CharField(max_length=50, blank=True)
     type = models.CharField(max_length=100, null=False, blank=False, choices=TYPE_CHOICES, default=TYPE_GENERIC)
@@ -390,9 +391,9 @@ class Dataset(models.Model):
 
 @python_2_unicode_compatible
 class Record(models.Model):
-    dataset = models.ForeignKey(Dataset, null=False, blank=False)
+    dataset = models.ForeignKey(Dataset, null=False, blank=False, on_delete=models.CASCADE)
     data = JSONField()
-    site = models.ForeignKey(Site, null=True, blank=True)
+    site = models.ForeignKey(Site, null=True, blank=True, on_delete=models.SET_NULL)
     # Fields for Observation and Species Observation
     datetime = models.DateTimeField(null=True, blank=True)
     geometry = models.GeometryField(srid=MODEL_SRID, spatial_index=True, null=True, blank=True)
@@ -482,8 +483,8 @@ class Record(models.Model):
 class DatasetFile(models.Model):
     file = models.FileField(upload_to='%Y/%m/%d')
     uploaded_date = models.DateTimeField(auto_now_add=True)
-    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True)
-    dataset = models.ForeignKey(Dataset, blank=False, null=True)
+    uploaded_by = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL)
+    dataset = models.ForeignKey(Dataset, blank=False, null=True, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.file.name

--- a/biosys/apps/main/tests/api/helpers.py
+++ b/biosys/apps/main/tests/api/helpers.py
@@ -249,7 +249,7 @@ class BaseUserTestCase(TestCase):
                 'file': fp,
             }
             resp = client.post(infer_url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # create the dataset. We should have to just add the project id from the returned data
             payload = resp.json()
             payload['project'] = project.pk
@@ -289,7 +289,7 @@ class BaseUserTestCase(TestCase):
         """
         dataset = self._create_dataset_from_rows(rows)
         resp = self._upload_records_from_rows(rows, dataset.pk)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         return dataset
 
 

--- a/biosys/apps/main/tests/api/test_auth.py
+++ b/biosys/apps/main/tests/api/test_auth.py
@@ -30,7 +30,7 @@ class TestBasicAuth(TestCase):
         basic_key = base64.b64encode(six.b("readonly:password")).decode('utf-8')
         client.credentials(HTTP_AUTHORIZATION='Basic ' + basic_key)
         resp = client.get(url)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_token_auth_end_point(self):
         """
@@ -48,7 +48,7 @@ class TestBasicAuth(TestCase):
             "password": "password"
         }
         resp = client.post(url, data=data, format='json')
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # check that we have a token
         self.assertTrue('token' in resp.data)
         token = resp.data.get('token')
@@ -77,4 +77,4 @@ class TestBasicAuth(TestCase):
         # set credential token
         client.credentials(HTTP_AUTHORIZATION='Token ' + token)
         resp = client.get(url)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/biosys/apps/main/tests/api/test_dataset.py
+++ b/biosys/apps/main/tests/api/test_dataset.py
@@ -197,7 +197,7 @@ class TestPermissions(helpers.BaseUserTestCase):
                     client.delete(url, data, format='json').status_code,
                     status.HTTP_204_NO_CONTENT
                 )
-                self.assertEquals(Dataset.objects.count(), count - 1)
+                self.assertEqual(Dataset.objects.count(), count - 1)
 
     def test_options(self):
         urls = [
@@ -230,12 +230,12 @@ class TestPermissions(helpers.BaseUserTestCase):
         url = reverse('api:dataset-list')
         client = self.admin_client
         resp = client.options(url)
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         data = resp.json()
         choices = data.get('actions', {}).get('POST', {}).get('type', {}).get('choices', None)
         self.assertTrue(choices)
         expected = [{'value': d[0], 'display_name': d[1]} for d in Dataset.TYPE_CHOICES]
-        self.assertEquals(expected, choices)
+        self.assertEqual(expected, choices)
 
 
 class TestDataPackageValidation(helpers.BaseUserTestCase):
@@ -400,7 +400,7 @@ class TestDataPackageValidation(helpers.BaseUserTestCase):
 
         project = self.project_1
         # project datum is not a Zone one
-        self.assertEquals(project.datum, 4326)
+        self.assertEqual(project.datum, 4326)
         self.assertFalse(is_projected_srid(project.datum))
 
         fields_no_zone = [
@@ -442,7 +442,7 @@ class TestDataPackageValidation(helpers.BaseUserTestCase):
         # check error message
         resp_data = resp.json()
         errors = resp_data.get('data_package')
-        self.assertEquals(len(errors), 1)
+        self.assertEqual(len(errors), 1)
         self.assertIn('Northing/easting coordinates require a zone', errors[0])
 
         # change the project datum
@@ -461,7 +461,7 @@ class TestDataPackageValidation(helpers.BaseUserTestCase):
 
         project = self.project_1
         # project datum is not a Zone one
-        self.assertEquals(project.datum, 4326)
+        self.assertEqual(project.datum, 4326)
         self.assertFalse(is_projected_srid(project.datum))
 
         fields = [
@@ -508,7 +508,7 @@ class TestDataPackageValidation(helpers.BaseUserTestCase):
         # check error message
         resp_data = resp.json()
         errors = resp_data.get('data_package')
-        self.assertEquals(len(errors), 1)
+        self.assertEqual(len(errors), 1)
         self.assertIn('Northing/easting coordinates require a zone', errors[0])
 
         # add required constraints
@@ -755,7 +755,7 @@ class TestDatasetRecordsSearchAndOrdering(helpers.BaseUserTestCase):
         resp = self.client.get(url + '?ordering=row', format='json')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         json_response = resp.json()
-        self.assertEquals(len(json_response), 11)
+        self.assertEqual(len(json_response), 11)
 
         # row start at 2
         sorted_rows = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -767,7 +767,7 @@ class TestDatasetRecordsSearchAndOrdering(helpers.BaseUserTestCase):
         resp = self.client.get(url + '?ordering=-row', format='json')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         json_response = resp.json()
-        self.assertEquals(len(json_response), 11)
+        self.assertEqual(len(json_response), 11)
 
         record_rows = [record['source_info']['row'] for record in json_response]
         self.assertEqual(record_rows, list(reversed(sorted_rows)))

--- a/biosys/apps/main/tests/api/test_explorer.py
+++ b/biosys/apps/main/tests/api/test_explorer.py
@@ -46,4 +46,4 @@ class TestView(TestCase):
     def test_logged_in_happy_path(self):
         url = reverse('doc-swagger')
         resp = self.readonly_client.get(url, follow=True)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -304,7 +304,7 @@ class TestDataValidation(TestCase):
         self.assertIsNotNone(self.record_1)
         self.assertTrue(self.record_1.is_custodian(self.custodian_1_user))
         self.assertIsNotNone(self.record_1.site)
-        self.assertEquals(self.site_1, self.record_1.site)
+        self.assertEqual(self.site_1, self.record_1.site)
 
     def test_create_one_happy_path(self):
         """
@@ -324,7 +324,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(Record.objects.count(), count + 1)
+        self.assertEqual(Record.objects.count(), count + 1)
 
     def test_empty_not_allowed(self):
         record = self.record_1
@@ -341,7 +341,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(Record.objects.count(), count)
+        self.assertEqual(Record.objects.count(), count)
 
     def test_create_column_not_in_schema(self):
         """
@@ -364,7 +364,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(Record.objects.count(), count)
+        self.assertEqual(Record.objects.count(), count)
 
     def test_update_column_not_in_schema(self):
         """
@@ -387,12 +387,12 @@ class TestDataValidation(TestCase):
             client.put(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(Record.objects.count(), count)
+        self.assertEqual(Record.objects.count(), count)
         self.assertEqual(
             client.patch(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(Record.objects.count(), count)
+        self.assertEqual(Record.objects.count(), count)
 
 
 class TestSiteExtraction(TestCase):
@@ -431,7 +431,7 @@ class TestSiteExtraction(TestCase):
         self.assertIsNotNone(self.record_1)
         self.assertTrue(self.record_1.is_custodian(self.custodian_1_user))
         self.assertIsNotNone(self.record_1.site)
-        self.assertEquals(self.site_1, self.record_1.site)
+        self.assertEqual(self.site_1, self.record_1.site)
 
     def test_create_with_site(self):
         """
@@ -441,7 +441,7 @@ class TestSiteExtraction(TestCase):
         """
         # clear all records
         Record.objects.all().delete()
-        self.assertEquals(Record.objects.count(), 0)
+        self.assertEqual(Record.objects.count(), 0)
         record = self.record_1
         data = {
             "dataset": record.dataset.pk,
@@ -456,8 +456,8 @@ class TestSiteExtraction(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(Record.objects.count(), 1)
-        self.assertEquals(Record.objects.first().site, expected_site)
+        self.assertEqual(Record.objects.count(), 1)
+        self.assertEqual(Record.objects.first().site, expected_site)
 
     def test_update_site(self):
         record = Record.objects.filter(site=self.site_1).first()
@@ -533,7 +533,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # check headers
         self.assertEqual(resp.get('content-type'),
                          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
@@ -543,22 +543,22 @@ class TestExport(helpers.BaseUserTestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
+        self.assertEqual(ext, '.xlsx')
         filename.startswith(dataset.name)
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(dataset.name, sheet_names[0])
-        ws = wb.get_sheet_by_name(dataset.name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(dataset.name, sheet_names[0])
+        ws = wb[dataset.name]
         rows = list(ws.rows)
         expected_records = Record.objects.filter(dataset=dataset)
-        self.assertEquals(len(rows), expected_records.count() + 1)
+        self.assertEqual(len(rows), expected_records.count() + 1)
         headers = [c.value for c in rows[0]]
         schema = dataset.schema
         # all the columns of the schema should be in the excel
-        self.assertEquals(schema.headers, headers)
+        self.assertEqual(schema.headers, headers)
 
     def test_permission_ok_for_not_custodian(self):
         """Export is a read action. Should be authorised for every logged-in user."""
@@ -573,7 +573,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_permission_denied_if_not_logged_in(self):
         """Must be logged-in."""
@@ -588,7 +588,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_excel_type(self):
         schema_fields = [
@@ -655,10 +655,10 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # load workbook
         wb = load_workbook(six.BytesIO(resp.content))
-        ws = wb.get_sheet_by_name(dataset.name)
+        ws = wb[dataset.name]
         rows = list(ws.rows)
         self.assertEqual(len(rows), 2)
         cells = rows[1]
@@ -692,30 +692,30 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
 
         # no filters
         resp = client.get(url)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected_whats = sorted(['Crashed the db', 'Restored the db', 'Canis lupus', 'Chubby bat'])
-        self.assertEquals(sorted([r['data']['What'] for r in records]), expected_whats)
+        self.assertEqual(sorted([r['data']['What'] for r in records]), expected_whats)
 
         # dataset__id
         expected_dataset = dataset1
         url = reverse('api:record-list')
         resp = client.get(url, {'dataset__id': expected_dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 2)
+        self.assertEqual(len(records), 2)
         expected_whats = sorted(['Crashed the db', 'Restored the db'])
-        self.assertEquals(sorted([r['data']['What'] for r in records]), expected_whats)
+        self.assertEqual(sorted([r['data']['What'] for r in records]), expected_whats)
 
         # dataset__name
         expected_dataset = dataset2
         resp = client.get(url, {'dataset__name': expected_dataset.name})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 2)
+        self.assertEqual(len(records), 2)
         expected_whats = sorted(['Canis lupus', 'Chubby bat'])
-        self.assertEquals(sorted([r['data']['What'] for r in records]), expected_whats)
+        self.assertEqual(sorted([r['data']['What'] for r in records]), expected_whats)
 
     def test_search_in_json_data(self):
         """
@@ -740,22 +740,22 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
 
         # search Serge in dataset1
         resp = client.get(url, {'search': 'Serge', 'dataset__id': dataset1.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 1)
+        self.assertEqual(len(records), 1)
         record = records[0]
         expected_data = sorted(['Crashed the db', '2018-02-14', 'Serge'])
-        self.assertEquals(sorted(list(record['data'].values())), expected_data)
+        self.assertEqual(sorted(list(record['data'].values())), expected_data)
 
         # search serge in dataset2 case insensitive
         resp = client.get(url, {'search': 'Serge', 'dataset__id': dataset2.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 1)
+        self.assertEqual(len(records), 1)
         record = records[0]
         expected_data = sorted(['Chubby Serge', '2017-05-18', '-34.4', '116.78'])
         record_values_as_string = [str(v) for v in record['data'].values()]
-        self.assertEquals(sorted(list(record_values_as_string)), expected_data)
+        self.assertEqual(sorted(list(record_values_as_string)), expected_data)
 
     def test_string_ordering_in_json_data(self):
         """
@@ -777,27 +777,27 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
         # order by What asc
         ordering = 'What'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected_whats = sorted(['Alligator', 'Canis lupus', 'Chubby bat', 'Zebra'])
-        self.assertEquals([r['data']['What'] for r in records], expected_whats)
+        self.assertEqual([r['data']['What'] for r in records], expected_whats)
 
         # order by What desc
         ordering = '-What'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected_whats = sorted(['Alligator', 'Canis lupus', 'Chubby bat', 'Zebra'], reverse=True)
-        self.assertEquals([r['data']['What'] for r in records], expected_whats)
+        self.assertEqual([r['data']['What'] for r in records], expected_whats)
 
         # test that the ordering is case sensitive
         ordering = 'what'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected_whats = sorted(['Alligator', 'Canis lupus', 'Chubby bat', 'Zebra'])
         self.assertNotEquals([r['data']['What'] for r in records], expected_whats)
 
@@ -828,7 +828,7 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         json_response = resp.json()
-        self.assertEquals(len(json_response), 11)
+        self.assertEqual(len(json_response), 11)
 
         # row start at 2
         sorted_rows = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
@@ -841,7 +841,7 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         json_response = resp.json()
-        self.assertEquals(len(json_response), 11)
+        self.assertEqual(len(json_response), 11)
 
         record_rows = [record['source_info']['row'] for record in json_response]
         self.assertEqual(record_rows, list(reversed(sorted_rows)))
@@ -860,18 +860,18 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
             ['Alligator', 10]
         ])
         # check that we have a field of type integer
-        self.assertEquals(dataset.schema.get_field_by_name('How Many').type, 'integer')
+        self.assertEqual(dataset.schema.get_field_by_name('How Many').type, 'integer')
 
         client = self.custodian_1_client
         url = reverse('api:record-list')
 
         ordering = 'How Many'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected = [('Zebra', 1), ('Canis lupus', 7), ('Chubby bat', 9), ('Alligator', 10)]
-        self.assertEquals([(r['data']['What'], r['data']['How Many']) for r in records], expected)
+        self.assertEqual([(r['data']['What'], r['data']['How Many']) for r in records], expected)
 
     def test_numeric_ordering_in_json_data_from_post_end_point(self):
         """
@@ -894,7 +894,7 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
             ['Alligator', weights[3]]
         ])
         # check that we have a field of type integer
-        self.assertEquals(dataset.schema.get_field_by_name('Weight').type, 'number')
+        self.assertEqual(dataset.schema.get_field_by_name('Weight').type, 'number')
         # post some records
         records_data = [
             {
@@ -922,21 +922,21 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
 
         ordering = 'Weight'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         expected = [('Chubby bat', 2.6), ('Canis lupus', 23.6), ('Zebra', 123.4), ('Alligator', 203.4)]
-        self.assertEquals([(r['data']['What'], r['data']['Weight']) for r in records], expected)
+        self.assertEqual([(r['data']['What'], r['data']['Weight']) for r in records], expected)
 
         # revert ordering
         ordering = '-Weight'
         resp = client.get(url, {'ordering': ordering, 'dataset__id': dataset.pk})
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         records = resp.json()
-        self.assertEquals(len(records), 4)
+        self.assertEqual(len(records), 4)
         # reverse expected
         expected = expected[::-1]
-        self.assertEquals([(r['data']['What'], r['data']['Weight']) for r in records], expected)
+        self.assertEqual([(r['data']['What'], r['data']['Weight']) for r in records], expected)
 
 
 class TestSchemaValidation(helpers.BaseUserTestCase):
@@ -992,7 +992,7 @@ class TestSchemaValidation(helpers.BaseUserTestCase):
             ['  ', '   ', '  ', '  '],
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk, strict=True)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_required_date_with_format_any(self):
         """
@@ -1020,10 +1020,10 @@ class TestSchemaValidation(helpers.BaseUserTestCase):
             ['   ', 'something'],
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk, strict=True)
-        self.assertEquals(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         received = resp.json()
         self.assertIsInstance(received, list)
-        self.assertEquals(len(received), 3)
+        self.assertEqual(len(received), 3)
         # this what an report should look like
         expected_row_report = {
             'row': 3,
@@ -1034,7 +1034,7 @@ class TestSchemaValidation(helpers.BaseUserTestCase):
             errors = row_report.get('errors')
             self.assertIn('DateAny', errors)
             msg = errors.get('DateAny')
-            self.assertEquals(msg, expected_row_report['errors']['DateAny'])
+            self.assertEqual(msg, expected_row_report['errors']['DateAny'])
 
 
 class TestPatch(helpers.BaseUserTestCase):

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -466,7 +466,7 @@ class TestSiteExtraction(TestCase):
         # need to test if the site belongs to the dataset project or the update won't happen
         self.assertIsNotNone(site)
         self.assertTrue(site.project == record.dataset.project)
-        self.assertNotEquals(record.site, site)
+        self.assertNotEqual(record.site, site)
         # update site value
         schema = record.dataset.schema
         site_column = schema.get_fk_for_model('Site').data_field
@@ -799,7 +799,7 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
         records = resp.json()
         self.assertEqual(len(records), 4)
         expected_whats = sorted(['Alligator', 'Canis lupus', 'Chubby bat', 'Zebra'])
-        self.assertNotEquals([r['data']['What'] for r in records], expected_whats)
+        self.assertNotEqual([r['data']['What'] for r in records], expected_whats)
 
     def test_server_side_ordering_row_number(self):
         """
@@ -884,7 +884,7 @@ class TestFilteringAndOrdering(helpers.BaseUserTestCase):
         # while a string sorted should return ['123.4', '2.6', '203.4', '23.6']
         float_sorted = sorted(weights)
         string_sorted = sorted([str(w) for w in weights])
-        self.assertNotEquals(float_sorted, [float(s) for s in string_sorted])
+        self.assertNotEqual(float_sorted, [float(s) for s in string_sorted])
 
         dataset = self._create_dataset_from_rows([
             ['What', 'Weight'],

--- a/biosys/apps/main/tests/api/test_generic_record.py
+++ b/biosys/apps/main/tests/api/test_generic_record.py
@@ -548,7 +548,7 @@ class TestExport(helpers.BaseUserTestCase):
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(dataset.name, sheet_names[0])
         ws = wb[dataset.name]

--- a/biosys/apps/main/tests/api/test_misc.py
+++ b/biosys/apps/main/tests/api/test_misc.py
@@ -101,18 +101,18 @@ class TestStatistics(TestCase):
             },
             'sites': {'total': 0},
         }
-        self.assertEquals(expected, resp.json())
+        self.assertEqual(expected, resp.json())
 
         # create one project
         project = G(Project)
-        self.assertEquals(1, Project.objects.count())
+        self.assertEqual(1, Project.objects.count())
         expected['projects']['total'] = 1
         resp = client.get(self.url)
         self.assertEqual(
             resp.status_code,
             status.HTTP_200_OK
         )
-        self.assertEquals(expected, resp.json())
+        self.assertEqual(expected, resp.json())
 
         # create some sites
         count = 3
@@ -124,7 +124,7 @@ class TestStatistics(TestCase):
             resp.status_code,
             status.HTTP_200_OK
         )
-        self.assertEquals(expected, resp.json())
+        self.assertEqual(expected, resp.json())
 
     def test_not_allowed_methods(self):
         user = G(get_user_model())

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -2080,7 +2080,7 @@ class TestExport(helpers.BaseUserTestCase):
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(dataset.name, sheet_names[0])
         ws = wb[dataset.name]

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -621,7 +621,7 @@ class TestSiteExtraction(TestCase):
         # need to test if the site belongs to the dataset project or the update won't happen
         self.assertIsNotNone(site)
         self.assertEqual(site.project, record.dataset.project)
-        self.assertNotEquals(record.site, site)
+        self.assertNotEqual(record.site, site)
         # update site value
         schema = record.dataset.schema
         site_column = schema.get_fk_for_model('Site').data_field
@@ -1023,8 +1023,8 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         # convert it back to GAD / zone 50 -> srid = 28350
         geom.transform(28350)
         # compare with 2 decimal place precision. Should be different that of expected
-        self.assertNotAlmostEquals(geom.x, easting, places=2)
-        self.assertNotAlmostEquals(geom.y, northing, places=2)
+        self.assertNotAlmostEqual(geom.x, easting, places=2)
+        self.assertNotAlmostEqual(geom.y, northing, places=2)
 
         # send path to update the zone
         record_data = {

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -354,7 +354,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), count + 1)
+        self.assertEqual(ds.record_queryset.count(), count + 1)
 
     def test_empty_not_allowed(self):
         ds = self.ds_1
@@ -370,7 +370,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
 
     def test_create_column_not_in_schema(self):
         """
@@ -394,7 +394,7 @@ class TestDataValidation(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
 
     def test_update_column_not_in_schema(self):
         """
@@ -418,12 +418,12 @@ class TestDataValidation(TestCase):
             client.put(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
         self.assertEqual(
             client.patch(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
 
     def test_date_error(self):
         """
@@ -449,7 +449,7 @@ class TestDataValidation(TestCase):
                 client.post(url_post, data, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), count + 1)
+            self.assertEqual(ds.record_queryset.count(), count + 1)
 
         invalid_values = [None, '', 'abcd']
         for value in invalid_values:
@@ -473,7 +473,7 @@ class TestDataValidation(TestCase):
                 client.patch(url_update, data, format='json').status_code,
                 status.HTTP_400_BAD_REQUEST
             )
-            self.assertEquals(ds.record_queryset.count(), count)
+            self.assertEqual(ds.record_queryset.count(), count)
 
     def test_geometry_error(self):
         """
@@ -499,7 +499,7 @@ class TestDataValidation(TestCase):
                 client.post(url_post, data, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), count + 1)
+            self.assertEqual(ds.record_queryset.count(), count + 1)
 
         invalid_values = [None, '', 'abcd']
         for value in invalid_values:
@@ -523,7 +523,7 @@ class TestDataValidation(TestCase):
                 client.patch(url_update, data, format='json').status_code,
                 status.HTTP_400_BAD_REQUEST
             )
-            self.assertEquals(ds.record_queryset.count(), count)
+            self.assertEqual(ds.record_queryset.count(), count)
 
 
 class TestSiteExtraction(TestCase):
@@ -595,7 +595,7 @@ class TestSiteExtraction(TestCase):
         # clear all records
         ds = self.ds_1
         ds.record_queryset.delete()
-        self.assertEquals(ds.record_queryset.count(), 0)
+        self.assertEqual(ds.record_queryset.count(), 0)
         record = self.record_1
         data = {
             "dataset": record.dataset.pk,
@@ -610,8 +610,8 @@ class TestSiteExtraction(TestCase):
             client.post(url, data, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
-        self.assertEquals(ds.record_queryset.first().site, expected_site)
+        self.assertEqual(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.first().site, expected_site)
 
     def test_update_site(self):
         ds = self.ds_1
@@ -620,7 +620,7 @@ class TestSiteExtraction(TestCase):
         site = Site.objects.filter(name="Site1").first()
         # need to test if the site belongs to the dataset project or the update won't happen
         self.assertIsNotNone(site)
-        self.assertEquals(site.project, record.dataset.project)
+        self.assertEqual(site.project, record.dataset.project)
         self.assertNotEquals(record.site, site)
         # update site value
         schema = record.dataset.schema
@@ -733,7 +733,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
         client = self.custodian_1_client
         schema = self.schema_with_lat_long_and_date()
         dataset = self._create_dataset_with_schema(project, client, schema, dataset_type=Dataset.TYPE_OBSERVATION)
-        self.assertEquals(dataset.record_queryset.count(), 0)
+        self.assertEqual(dataset.record_queryset.count(), 0)
         record_data = {
             'What': 'A test',
             'When': '01/06/2017',
@@ -750,9 +750,9 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(dataset.record_queryset.count(), 1)
+        self.assertEqual(dataset.record_queryset.count(), 1)
         record = dataset.record_queryset.first()
-        self.assertEquals(timezone.localtime(record.datetime).date(), expected_date)
+        self.assertEqual(timezone.localtime(record.datetime).date(), expected_date)
         geometry = record.geometry
         self.assertIsInstance(geometry, Point)
         self.assertEqual(geometry.x, 116.0)
@@ -768,7 +768,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
         client = self.custodian_1_client
         schema = self.schema_with_lat_long_and_date()
         dataset = self._create_dataset_with_schema(project, client, schema, dataset_type=Dataset.TYPE_OBSERVATION)
-        self.assertEquals(dataset.record_queryset.count(), 0)
+        self.assertEqual(dataset.record_queryset.count(), 0)
         record_data = {
             'What': 'A test',
             'When': '01/06/2017',
@@ -807,10 +807,10 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.patch(url, data=payload, format='json').status_code,
             status.HTTP_200_OK
         )
-        self.assertEquals(dataset.record_queryset.count(), 1)
+        self.assertEqual(dataset.record_queryset.count(), 1)
         record.refresh_from_db()
         expected_date = datetime.date(2016, 4, 20)
-        self.assertEquals(timezone.localtime(record.datetime).date(), expected_date)
+        self.assertEqual(timezone.localtime(record.datetime).date(), expected_date)
         geometry = record.geometry
         self.assertIsInstance(geometry, Point)
         self.assertEqual(geometry.x, new_long)
@@ -824,7 +824,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
         client = self.custodian_1_client
         schema = self.schema_with_no_date()
         dataset = self._create_dataset_with_schema(project, client, schema, dataset_type=Dataset.TYPE_OBSERVATION)
-        self.assertEquals(dataset.record_queryset.count(), 0)
+        self.assertEqual(dataset.record_queryset.count(), 0)
         record_data = {
             'What': 'A test',
             'Latitude': -32.0,
@@ -839,7 +839,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(dataset.record_queryset.count(), 1)
+        self.assertEqual(dataset.record_queryset.count(), 1)
         record = dataset.record_queryset.first()
         self.assertIsNone(record.datetime)
         geometry = record.geometry
@@ -855,7 +855,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
         client = self.custodian_1_client
         schema = self.schema_with_no_date()
         dataset = self._create_dataset_with_schema(project, client, schema, dataset_type=Dataset.TYPE_OBSERVATION)
-        self.assertEquals(dataset.record_queryset.count(), 0)
+        self.assertEqual(dataset.record_queryset.count(), 0)
         record_data = {
             'What': 'A test',
             'Latitude': -32.0,
@@ -887,7 +887,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.patch(url, data=payload, format='json').status_code,
             status.HTTP_200_OK
         )
-        self.assertEquals(dataset.record_queryset.count(), 1)
+        self.assertEqual(dataset.record_queryset.count(), 1)
         record.refresh_from_db()
         self.assertIsNone(record.datetime)
         geometry = record.geometry
@@ -975,7 +975,7 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         resp = client.post(url, data=payload, format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         qs = dataset.record_queryset
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
         record = qs.first()
         geom = record.geometry
         # should be in WGS84 -> srid = 4326
@@ -983,8 +983,8 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         # convert it back to GAD / zone 50 -> srid = 28350
         geom.transform(28350)
         # compare with 2 decimal place precision
-        self.assertAlmostEquals(geom.x, easting, places=2)
-        self.assertAlmostEquals(geom.y, northing, places=2)
+        self.assertAlmostEqual(geom.x, easting, places=2)
+        self.assertAlmostEqual(geom.y, northing, places=2)
 
     def test_update_happy_path(self):
         project = self.project_1
@@ -1015,7 +1015,7 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         resp = client.post(url, data=payload, format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         qs = dataset.record_queryset
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
         record = qs.first()
         geom = record.geometry
         # should be in WGS84 -> srid = 4326
@@ -1047,8 +1047,8 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         self.assertEqual(geom.srid, 4326)
         # convert it back to GAD / zone 50 -> srid = 28350
         geom.transform(28350)
-        self.assertAlmostEquals(geom.x, easting, places=2)
-        self.assertAlmostEquals(geom.y, northing, places=2)
+        self.assertAlmostEqual(geom.x, easting, places=2)
+        self.assertAlmostEqual(geom.y, northing, places=2)
 
     def test_default_datum(self):
         """
@@ -1124,7 +1124,7 @@ class TestEastingNorthing(helpers.BaseUserTestCase):
         resp = client.post(url, data=payload, format='json')
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         qs = dataset.record_queryset
-        self.assertEquals(qs.count(), 1)
+        self.assertEqual(qs.count(), 1)
         record = qs.first()
         geom = record.geometry
         # should be in WGS84 -> srid = 4326
@@ -1557,16 +1557,16 @@ class TestGeometryFromSite(helpers.BaseUserTestCase):
             ['what_2', '02/02/2017', site_2_code]
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), len(csv_data) - 1)
+            self.assertEqual(records.count(), len(csv_data) - 1)
             r = [r for r in records if r.data['What'] == 'what_1'][0]
             self.assertEqual(r.site, site_1)
             self.assertEqual(r.geometry, site_1_geometry)
@@ -1599,17 +1599,17 @@ class TestGeometryFromSite(helpers.BaseUserTestCase):
             ['what_2', '02/02/2017', site_2_code]
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, data=payload, format='multipart')
-            self.assertEquals(resp.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
             # Check that the good record is there.
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), 1)
+            self.assertEqual(records.count(), 1)
             r = records.first()
             self.assertEqual(r.site, site_1)
             self.assertEqual(r.geometry, site_1_geometry)
@@ -1642,16 +1642,16 @@ class TestGeometryFromSite(helpers.BaseUserTestCase):
             ['what_2', '02/02/2017', site_2_code]
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), len(csv_data) - 1)
+            self.assertEqual(records.count(), len(csv_data) - 1)
             record_1 = [r for r in records if r.data['What'] == 'what_1'][0]
             self.assertEqual(record_1.site, site_1)
             self.assertEqual(record_1.geometry, site_1_geometry)
@@ -1945,8 +1945,8 @@ class TestGeometryConversion(helpers.BaseUserTestCase):
         )
         self.assertIsNotNone(record)
         self.assertIsNotNone(record.geometry)
-        self.assertEquals(record.geometry.x, 115.75)
-        self.assertEquals(record.geometry.y, -32.0)
+        self.assertEqual(record.geometry.x, 115.75)
+        self.assertEqual(record.geometry.y, -32.0)
 
         # try with the upload end-point
         dataset.record_set.all().delete()
@@ -1959,12 +1959,12 @@ class TestGeometryConversion(helpers.BaseUserTestCase):
             dataset.pk,
             strict=True
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         record = dataset.record_set.last()
         self.assertIsNotNone(record)
         self.assertIsNotNone(record.geometry)
-        self.assertEquals(record.geometry.x, 115.75)
-        self.assertEquals(record.geometry.y, -32.0)
+        self.assertEqual(record.geometry.x, 115.75)
+        self.assertEqual(record.geometry.y, -32.0)
 
 
 class TestSerialization(TestCase):
@@ -2065,7 +2065,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # check headers
         self.assertEqual(resp.get('content-type'),
                          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
@@ -2075,22 +2075,22 @@ class TestExport(helpers.BaseUserTestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
+        self.assertEqual(ext, '.xlsx')
         filename.startswith(dataset.name)
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(dataset.name, sheet_names[0])
-        ws = wb.get_sheet_by_name(dataset.name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(dataset.name, sheet_names[0])
+        ws = wb[dataset.name]
         rows = list(ws.rows)
         expected_records = Record.objects.filter(dataset=dataset)
-        self.assertEquals(len(rows), expected_records.count() + 1)
+        self.assertEqual(len(rows), expected_records.count() + 1)
         headers = [c.value for c in rows[0]]
         schema = dataset.schema
         # all the columns of the schema should be in the excel
-        self.assertEquals(schema.headers, headers)
+        self.assertEqual(schema.headers, headers)
 
     def test_permission_ok_for_not_custodian(self):
         """Export is a read action. Should be authorised for every logged-in user."""
@@ -2105,7 +2105,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_permission_denied_if_not_logged_in(self):
         """Must be logged-in."""
@@ -2120,7 +2120,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestDateNotMandatory(helpers.BaseUserTestCase):

--- a/biosys/apps/main/tests/api/test_project.py
+++ b/biosys/apps/main/tests/api/test_project.py
@@ -291,12 +291,12 @@ class TestPermissions(TestCase):
         url = reverse('api:project-list')
         client = self.admin_client
         resp = client.options(url)
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         data = resp.json()
         datum_choices = data.get('actions', {}).get('POST', {}).get('datum', {}).get('choices', None)
         self.assertTrue(datum_choices)
         expected = [{'value': d[0], 'display_name': d[1]} for d in DATUM_CHOICES]
-        self.assertEquals(expected, datum_choices)
+        self.assertEqual(expected, datum_choices)
 
 
 class TestProjectSiteBulk(TestCase):
@@ -559,8 +559,8 @@ class TestProjectSiteBulk(TestCase):
         payload = 'all'
         resp = client.delete(url, payload, format='json')
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertEquals(Site.objects.filter(project=project).count(), 0)
-        self.assertEquals(Site.objects.filter(project=self.project_2).count(), previous_project2_sites_count)
+        self.assertEqual(Site.objects.filter(project=project).count(), 0)
+        self.assertEqual(Site.objects.filter(project=self.project_2).count(), previous_project2_sites_count)
 
 
 class TestProjectCustodians(TestCase):
@@ -624,7 +624,7 @@ class TestProjectCustodians(TestCase):
             'custodians': [custodian.pk, new_user.pk]
         }
         resp = client.patch(url, data, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         self.assertTrue(project.is_custodian(custodian))
         # new user is a custodian of the project
         self.assertTrue(project.is_custodian(new_user))
@@ -642,8 +642,8 @@ class TestProjectCustodians(TestCase):
         url = reverse('api:project-detail', kwargs={'pk': project.pk})
         expected_custodians = [custodian.pk]
         resp = client.get(url)
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
-        self.assertEquals(expected_custodians, resp.json()['custodians'])
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(expected_custodians, resp.json()['custodians'])
 
         # clear custodians list
         # custodians can't be empty
@@ -651,17 +651,17 @@ class TestProjectCustodians(TestCase):
             'custodians': []
         }
         resp = client.patch(url, data, format='json')
-        self.assertEquals(status.HTTP_400_BAD_REQUEST, resp.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, resp.status_code)
 
         # add someone else
         data = {
             'custodians': [self.custodian_2_user.pk]
         }
         resp = client.patch(url, data, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         resp = client.get(url)
         expected_custodians = data['custodians']
-        self.assertEquals(expected_custodians, resp.json()['custodians'])
+        self.assertEqual(expected_custodians, resp.json()['custodians'])
         # no more a custodian
         self.assertFalse(project.is_custodian(custodian))
 
@@ -683,5 +683,5 @@ class TestProjectCustodians(TestCase):
             'custodians': [custodian.pk]
         }
         resp = client.patch(url, data, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         self.assertTrue(project.is_custodian(custodian))

--- a/biosys/apps/main/tests/api/test_record_serialization.py
+++ b/biosys/apps/main/tests/api/test_record_serialization.py
@@ -40,15 +40,15 @@ class TestFieldSelection(helpers.BaseUserTestCase):
             'fields': 'geometry'
         }
         resp = client.get(url, data=query_params, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         records = resp.json()
         self.assertIsInstance(records, list)
         expected_record_count = len(self.rows) - 1
-        self.assertEquals(len(records), expected_record_count)
+        self.assertEqual(len(records), expected_record_count)
         expected_fields = ['geometry']
         for record in records:
             self.assertIsInstance(record, dict)
-            self.assertEquals(sorted(list(record.keys())), sorted(expected_fields))
+            self.assertEqual(sorted(list(record.keys())), sorted(expected_fields))
 
     def test_geometry_and_id(self):
         """
@@ -64,15 +64,15 @@ class TestFieldSelection(helpers.BaseUserTestCase):
             'fields': ['geometry', 'id']
         }
         resp = client.get(url, data=query_params, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         records = resp.json()
         self.assertIsInstance(records, list)
         expected_record_count = len(self.rows) - 1
-        self.assertEquals(len(records), expected_record_count)
+        self.assertEqual(len(records), expected_record_count)
         expected_fields = ['geometry', 'id']
         for record in records:
             self.assertIsInstance(record, dict)
-            self.assertEquals(sorted(list(record.keys())), sorted(expected_fields))
+            self.assertEqual(sorted(list(record.keys())), sorted(expected_fields))
 
     def test_geometry_and_id_record_end_point(self):
         """
@@ -89,21 +89,21 @@ class TestFieldSelection(helpers.BaseUserTestCase):
             'fields': ['geometry', 'id']
         }
         resp = client.get(url, data=query_params, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         records = resp.json()
         self.assertIsInstance(records, list)
         expected_record_count = len(self.rows) - 1
-        self.assertEquals(len(records), expected_record_count)
+        self.assertEqual(len(records), expected_record_count)
         expected_fields = ['geometry', 'id']
         for record in records:
             self.assertIsInstance(record, dict)
             # only key = geometry
-            self.assertEquals(sorted(list(record.keys())), sorted(expected_fields))
+            self.assertEqual(sorted(list(record.keys())), sorted(expected_fields))
             # request record individually
             url = reverse('api:record-detail', kwargs={'pk': record.get('id')})
             resp = client.get(url, data=query_params, format='json')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
-            self.assertEquals(sorted(list(resp.json().keys())), sorted(expected_fields))
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(sorted(list(resp.json().keys())), sorted(expected_fields))
 
     def test_not_existing_field(self):
         """
@@ -120,12 +120,12 @@ class TestFieldSelection(helpers.BaseUserTestCase):
             'fields': ['field_with_typo']
         }
         resp = client.get(url, data=query_params, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         records = resp.json()
         expected_fields = []
         for record in records:
             self.assertIsInstance(record, dict)
-            self.assertEquals(sorted(list(record.keys())), sorted(expected_fields))
+            self.assertEqual(sorted(list(record.keys())), sorted(expected_fields))
 
     def test_one_not_existing_field(self):
         """
@@ -142,12 +142,12 @@ class TestFieldSelection(helpers.BaseUserTestCase):
             'fields': ['geometry', 'field_with_typo']
         }
         resp = client.get(url, data=query_params, format='json')
-        self.assertEquals(status.HTTP_200_OK, resp.status_code)
+        self.assertEqual(status.HTTP_200_OK, resp.status_code)
         records = resp.json()
         expected_fields = ['geometry']
         for record in records:
             self.assertIsInstance(record, dict)
-            self.assertEquals(sorted(list(record.keys())), sorted(expected_fields))
+            self.assertEqual(sorted(list(record.keys())), sorted(expected_fields))
 
 
 class TestExcelFormat(helpers.BaseUserTestCase):
@@ -178,20 +178,20 @@ class TestExcelFormat(helpers.BaseUserTestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
+        self.assertEqual(ext, '.xlsx')
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named after the dataset
         expected_sheet_name = dataset.name
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(sheet_names[0], expected_sheet_name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(sheet_names[0], expected_sheet_name)
 
         # check rows values
-        ws = wb.get_sheet_by_name(expected_sheet_name)
+        ws = wb[expected_sheet_name]
         rows = list(ws.rows)
         # compare rows
-        self.assertEquals(len(rows), len(expected_rows))
+        self.assertEqual(len(rows), len(expected_rows))
         for (expected_values, xlsx_row) in zip(expected_rows, rows):
             actual_values = [c.value for c in xlsx_row]
             self.assertEqual(expected_values, actual_values)
@@ -225,11 +225,11 @@ class TestCSVFormat(helpers.BaseUserTestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.csv')
+        self.assertEqual(ext, '.csv')
         # read content
         reader = csv.reader(six.StringIO(resp.content.decode('utf-8')), dialect='excel')
         for expected_row, actual_row in zip(expected_rows, reader):
             expected_row_string = [str(v) for v in expected_row]
-            self.assertEquals(actual_row, expected_row_string)
+            self.assertEqual(actual_row, expected_row_string)
 
 

--- a/biosys/apps/main/tests/api/test_record_serialization.py
+++ b/biosys/apps/main/tests/api/test_record_serialization.py
@@ -183,7 +183,7 @@ class TestExcelFormat(helpers.BaseUserTestCase):
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named after the dataset
         expected_sheet_name = dataset.name
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(sheet_names[0], expected_sheet_name)
 

--- a/biosys/apps/main/tests/api/test_records_upload.py
+++ b/biosys/apps/main/tests/api/test_records_upload.py
@@ -45,7 +45,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
         ]
         file_ = helpers.rows_to_csv_file(csv_data)
         client = self.custodian_1_client
-        self.assertEquals(0, self.ds.record_queryset.count())
+        self.assertEqual(0, self.ds.record_queryset.count())
         file_name = path.basename(file_)
         with open(file_) as fp:
             data = {
@@ -53,10 +53,10 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # The records should be saved in order of the row
             qs = self.ds.record_queryset.order_by('pk')
-            self.assertEquals(len(csv_data) - 1, qs.count())
+            self.assertEqual(len(csv_data) - 1, qs.count())
 
             index = 0
             record = qs[index]
@@ -64,7 +64,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': 'A1',
                 'Column B': 'B1',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -80,7 +80,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': 'A2',
                 'Column B': 'B2',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -90,8 +90,8 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             }
             self.assertEqual(source_info, expected_info)
 
-            self.assertEquals(self.project_1.record_count, len(csv_data) - 1)
-            self.assertEquals(self.ds.record_count, len(csv_data) - 1)
+            self.assertEqual(self.project_1.record_count, len(csv_data) - 1)
+            self.assertEqual(self.ds.record_count, len(csv_data) - 1)
 
     def test_upload_xlsx_happy_path(self):
         csv_data = [
@@ -101,7 +101,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
         client = self.custodian_1_client
-        self.assertEquals(0, self.ds.record_queryset.count())
+        self.assertEqual(0, self.ds.record_queryset.count())
         file_name = path.basename(file_)
         with open(file_, 'rb') as fp:
             data = {
@@ -109,10 +109,10 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # The records should be saved in order of the row
             qs = self.ds.record_queryset.order_by('pk')
-            self.assertEquals(len(csv_data) - 1, qs.count())
+            self.assertEqual(len(csv_data) - 1, qs.count())
 
             index = 0
             record = qs[index]
@@ -120,7 +120,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': 'A1',
                 'Column B': 'B1',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -136,7 +136,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': 'A2',
                 'Column B': 'B2',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -146,8 +146,8 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             }
             self.assertEqual(source_info, expected_info)
 
-            self.assertEquals(self.project_1.record_count, len(csv_data) - 1)
-            self.assertEquals(self.ds.record_count, len(csv_data) - 1)
+            self.assertEqual(self.project_1.record_count, len(csv_data) - 1)
+            self.assertEqual(self.ds.record_count, len(csv_data) - 1)
 
     def test_upload_blank_column(self):
         """ Blank column should be ignored"""
@@ -158,7 +158,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
         client = self.custodian_1_client
-        self.assertEquals(0, self.ds.record_queryset.count())
+        self.assertEqual(0, self.ds.record_queryset.count())
         file_name = path.basename(file_)
         with open(file_, 'rb') as fp:
             data = {
@@ -166,17 +166,17 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # The records should be saved in order of the row
             qs = self.ds.record_queryset.order_by('pk')
-            self.assertEquals(len(csv_data) - 1, qs.count())
+            self.assertEqual(len(csv_data) - 1, qs.count())
             index = 0
             record = qs[index]
             expected_data = {
                 'Column A': 'A1',
                 'Column B': 'B1',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -192,7 +192,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': 'A2',
                 'Column B': 'B2',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
             # test that source_info contains the file_name and row_counter
             source_info = record.source_info
             self.assertIsNotNone(source_info)
@@ -202,8 +202,8 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             }
             self.assertEqual(source_info, expected_info)
 
-            self.assertEquals(self.project_1.record_count, len(csv_data) - 1)
-            self.assertEquals(self.ds.record_count, len(csv_data) - 1)
+            self.assertEqual(self.project_1.record_count, len(csv_data) - 1)
+            self.assertEqual(self.ds.record_count, len(csv_data) - 1)
 
     def test_unicode(self):
         """
@@ -215,17 +215,17 @@ class TestGenericRecord(helpers.BaseUserTestCase):
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
         client = self.custodian_1_client
-        self.assertEquals(0, self.ds.record_queryset.count())
+        self.assertEqual(0, self.ds.record_queryset.count())
         with open(file_, 'rb') as fp:
             data = {
                 'file': fp,
                 'strict': False
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # The records should be saved in order of the row
             qs = self.ds.record_queryset.order_by('pk')
-            self.assertEquals(len(csv_data) - 1, qs.count())
+            self.assertEqual(len(csv_data) - 1, qs.count())
 
             index = 0
             record = qs[index]
@@ -233,7 +233,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'Column A': u'Some char: \u1234',
                 'Column B': u'The euro char: \u20ac',
             }
-            self.assertEquals(expected_data, record.data)
+            self.assertEqual(expected_data, record.data)
 
     def test_headers_are_trimmed_csv(self):
         """
@@ -245,7 +245,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             fields
         ])
         schema = dataset.schema
-        self.assertEquals(schema.headers, fields)
+        self.assertEqual(schema.headers, fields)
 
         # upload record
         csv_data = [
@@ -261,13 +261,13 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
 
             # verify stored data
             record = dataset.record_queryset.first()
-            self.assertEquals(record.data.get('What'), 'Something')
-            self.assertEquals(record.data.get('When'), '2018-02-01')
-            self.assertEquals(record.data.get('Who'), 'me')
+            self.assertEqual(record.data.get('What'), 'Something')
+            self.assertEqual(record.data.get('When'), '2018-02-01')
+            self.assertEqual(record.data.get('Who'), 'me')
             # verify that the fields with space doesn't exists
             for f in csv_data[0]:
                 self.assertIsNone(record.data.get(f))
@@ -281,7 +281,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             fields
         ])
         schema = dataset.schema
-        self.assertEquals(schema.headers, fields)
+        self.assertEqual(schema.headers, fields)
 
         # upload record
         csv_data = [
@@ -297,13 +297,13 @@ class TestGenericRecord(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(url, data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
 
             # verify stored data
             record = dataset.record_queryset.first()
-            self.assertEquals(record.data.get('What'), 'Something')
-            self.assertEquals(record.data.get('When'), '2018-02-01')
-            self.assertEquals(record.data.get('Who'), 'me')
+            self.assertEqual(record.data.get('What'), 'Something')
+            self.assertEqual(record.data.get('When'), '2018-02-01')
+            self.assertEqual(record.data.get('Who'), 'me')
             # verify that the fields with space doesn't exists
             for f in csv_data[0]:
                 self.assertIsNone(record.data.get(f))
@@ -319,7 +319,7 @@ class TestGenericRecord(helpers.BaseUserTestCase):
             fields
         ])
         schema = dataset.schema
-        self.assertEquals(schema.headers, fields)
+        self.assertEqual(schema.headers, fields)
         # create record with trailing and heading space
         data = {
             'What  ': 'Something',
@@ -423,10 +423,10 @@ class TestObservation(helpers.BaseUserTestCase):
         }
         url = reverse('api:site-list')
         resp = self.client.post(url, data=payload, format='json')
-        self.assertEquals(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.site = Site.objects.filter(pk=resp.json().get('id')).first()
         self.assertIsNotNone(self.site)
-        self.assertEquals(self.site.code, 'COT')
+        self.assertEqual(self.site.code, 'COT')
 
     def test_site_no_date(self):
         csv_data = [
@@ -441,13 +441,13 @@ class TestObservation(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = self.dataset.record_queryset.all()
             self.assertEqual(len(records), 1)
             record = records[0]
             self.assertEqual(record.site, self.site)
             self.assertIsNone(record.datetime)
-            self.assertEquals(record.geometry, self.site.geometry)
+            self.assertEqual(record.geometry, self.site.geometry)
 
     def test_site_with_date(self):
         csv_data = [
@@ -462,11 +462,11 @@ class TestObservation(helpers.BaseUserTestCase):
                 'strict': True  # upload in strict mode
             }
             resp = client.post(self.url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = self.dataset.record_queryset.all()
             self.assertEqual(len(records), 1)
             record = records[0]
             self.assertEqual(record.site, self.site)
             expected_date = datetime.date(2017, 6, 4)
             self.assertEqual(timezone.localtime(record.datetime).date(), expected_date)
-            self.assertEquals(record.geometry, self.site.geometry)
+            self.assertEqual(record.geometry, self.site.geometry)

--- a/biosys/apps/main/tests/api/test_schema_inference.py
+++ b/biosys/apps/main/tests/api/test_schema_inference.py
@@ -86,7 +86,7 @@ class TestGenericSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # should be json
             self.assertEqual(resp.get('content-type'), 'application/json')
             received = resp.json()
@@ -94,10 +94,10 @@ class TestGenericSchema(InferTestBase):
             # name should be set with the file name
             self.assertIn('name', received)
             file_name = path.splitext(path.basename(fp.name))[0]
-            self.assertEquals(file_name, received.get('name'))
+            self.assertEqual(file_name, received.get('name'))
             # type should be 'generic'
             self.assertIn('type', received)
-            self.assertEquals('generic', received.get('type'))
+            self.assertEqual('generic', received.get('type'))
 
             # data_package verification
             self.assertIn('data_package', received)
@@ -106,28 +106,28 @@ class TestGenericSchema(InferTestBase):
             # verify schema
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
-            self.assertEquals(len(schema.fields), len(columns))
-            self.assertEquals(schema.field_names, columns)
+            self.assertEqual(len(schema.fields), len(columns))
+            self.assertEqual(schema.field_names, columns)
 
             field = schema.get_field_by_name('Name')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Age')
-            self.assertEquals(field.type, 'integer')
+            self.assertEqual(field.type, 'integer')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Weight')
-            self.assertEquals(field.type, 'number')
+            self.assertEqual(field.type, 'number')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Comments')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
     def test_generic_string_and_number_simple_csv(self):
         """
@@ -146,7 +146,7 @@ class TestGenericSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # should be json
             self.assertEqual(resp.get('content-type'), 'application/json')
             received = resp.json()
@@ -154,10 +154,10 @@ class TestGenericSchema(InferTestBase):
             # name should be set with the file name
             self.assertIn('name', received)
             file_name = path.splitext(path.basename(fp.name))[0]
-            self.assertEquals(file_name, received.get('name'))
+            self.assertEqual(file_name, received.get('name'))
             # type should be 'generic'
             self.assertIn('type', received)
-            self.assertEquals('generic', received.get('type'))
+            self.assertEqual('generic', received.get('type'))
 
             # data_package verification
             self.assertIn('data_package', received)
@@ -166,28 +166,28 @@ class TestGenericSchema(InferTestBase):
             # verify schema
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
-            self.assertEquals(len(schema.fields), len(columns))
-            self.assertEquals(schema.field_names, columns)
+            self.assertEqual(len(schema.fields), len(columns))
+            self.assertEqual(schema.field_names, columns)
 
             field = schema.get_field_by_name('Name')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Age')
-            self.assertEquals(field.type, 'integer')
+            self.assertEqual(field.type, 'integer')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Weight')
-            self.assertEquals(field.type, 'number')
+            self.assertEqual(field.type, 'number')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Comments')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
     def test_generic_date_iso_xls(self):
         """
@@ -210,7 +210,7 @@ class TestGenericSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # data_package verification
             self.assertIn('data_package', received)
@@ -220,14 +220,14 @@ class TestGenericSchema(InferTestBase):
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
             field = schema.get_field_by_name('What')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('When')
-            self.assertEquals(field.type, 'date')
+            self.assertEqual(field.type, 'date')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'any')
+            self.assertEqual(field.format, 'any')
 
     def test_mix_types_infer_most_plausible(self):
         """
@@ -253,7 +253,7 @@ class TestGenericSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # data_package verification
             self.assertIn('data_package', received)
@@ -263,7 +263,7 @@ class TestGenericSchema(InferTestBase):
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
             field = schema.get_field_by_name('How Many')
-            self.assertEquals(field.type, 'integer')
+            self.assertEqual(field.type, 'integer')
 
     def test_csv_with_excel_content_type(self):
         """
@@ -297,7 +297,7 @@ class TestGenericSchema(InferTestBase):
             token, _ = Token.objects.get_or_create(user=user)
             force_authenticate(request, user=self.custodian_1_user, token=token)
             resp = view(request).render()
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             # should be json
             self.assertEqual(resp.get('content-type'), 'application/json')
             if six.PY3:
@@ -309,10 +309,10 @@ class TestGenericSchema(InferTestBase):
             # name should be set with the file name
             self.assertIn('name', received)
             file_name = path.splitext(path.basename(fp.name))[0]
-            self.assertEquals(file_name, received.get('name'))
+            self.assertEqual(file_name, received.get('name'))
             # type should be 'generic'
             self.assertIn('type', received)
-            self.assertEquals('generic', received.get('type'))
+            self.assertEqual('generic', received.get('type'))
 
             # data_package verification
             self.assertIn('data_package', received)
@@ -321,28 +321,28 @@ class TestGenericSchema(InferTestBase):
             # verify schema
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
-            self.assertEquals(len(schema.fields), len(columns))
-            self.assertEquals(schema.field_names, columns)
+            self.assertEqual(len(schema.fields), len(columns))
+            self.assertEqual(schema.field_names, columns)
 
             field = schema.get_field_by_name('Name')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Age')
-            self.assertEquals(field.type, 'integer')
+            self.assertEqual(field.type, 'integer')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Weight')
-            self.assertEquals(field.type, 'number')
+            self.assertEqual(field.type, 'number')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
             field = schema.get_field_by_name('Comments')
-            self.assertEquals(field.type, 'string')
+            self.assertEqual(field.type, 'string')
             self.assertFalse(field.required)
-            self.assertEquals(field.format, 'default')
+            self.assertEqual(field.format, 'default')
 
 
 class TestObservationSchema(InferTestBase):
@@ -372,7 +372,7 @@ class TestObservationSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # data_package verification
             self.assertIn('data_package', received)
@@ -382,15 +382,15 @@ class TestObservationSchema(InferTestBase):
             schema = utils_data_package.GenericSchema(schema_descriptor)
             lat_field = schema.get_field_by_name('Latitude')
             lon_field = schema.get_field_by_name('Longitude')
-            self.assertEquals(lat_field.type, 'number')
-            self.assertEquals(lon_field.type, 'number')
+            self.assertEqual(lat_field.type, 'number')
+            self.assertEqual(lon_field.type, 'number')
             self.assertTrue(lat_field.required)
             self.assertTrue(lon_field.required)
             # biosys types
             self.assertTrue(BiosysSchema(lat_field.get(BiosysSchema.BIOSYS_KEY_NAME)).is_latitude())
             self.assertTrue(BiosysSchema(lon_field.get(BiosysSchema.BIOSYS_KEY_NAME)).is_longitude())
 
-            self.assertEquals(Dataset.TYPE_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_OBSERVATION, received.get('type'))
             # test biosys validity
             self.verify_inferred_data(received)
 
@@ -416,35 +416,35 @@ class TestObservationSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # type observation
-            self.assertEquals(Dataset.TYPE_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_OBSERVATION, received.get('type'))
 
             # verify fields attributes
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
             lat_field = schema.get_field_by_name('Latitude')
-            self.assertEquals(lat_field.type, 'number')
+            self.assertEqual(lat_field.type, 'number')
             self.assertTrue(lat_field.required)
             biosys = lat_field.get('biosys')
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.LATITUDE_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.LATITUDE_TYPE_NAME)
 
             lon_field = schema.get_field_by_name('Longitude')
-            self.assertEquals(lon_field.type, 'number')
+            self.assertEqual(lon_field.type, 'number')
             self.assertTrue(lon_field.required)
             biosys = lon_field.get('biosys')
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.LONGITUDE_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.LONGITUDE_TYPE_NAME)
 
             # datum
             datum_field = schema.get_field_by_name('Datum')
-            self.assertEquals(datum_field.type, 'string')
+            self.assertEqual(datum_field.type, 'string')
             self.assertFalse(datum_field.required)
             biosys = datum_field.get('biosys')
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.DATUM_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.DATUM_TYPE_NAME)
 
             # test that we can save the dataset back.
             self.verify_inferred_data(received)
@@ -472,10 +472,10 @@ class TestObservationSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # should be an observation
-            self.assertEquals(Dataset.TYPE_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_OBSERVATION, received.get('type'))
             # data_package verification
             self.assertIn('data_package', received)
 
@@ -484,30 +484,30 @@ class TestObservationSchema(InferTestBase):
             schema = utils_data_package.GenericSchema(schema_descriptor)
             east_field = schema.get_field_by_name('Easting')
             self.assertIsNotNone(east_field)
-            self.assertEquals(east_field.type, 'number')
+            self.assertEqual(east_field.type, 'number')
             self.assertTrue(east_field.required)
             biosys = east_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.EASTING_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.EASTING_TYPE_NAME)
 
             north_field = schema.get_field_by_name('Northing')
             self.assertIsNotNone(north_field)
-            self.assertEquals(north_field.type, 'number')
+            self.assertEqual(north_field.type, 'number')
             self.assertTrue(north_field.required)
             biosys = north_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.NORTHING_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.NORTHING_TYPE_NAME)
 
             datum_field = schema.get_field_by_name('Datum')
             self.assertIsNotNone(datum_field)
-            self.assertEquals(datum_field.type, 'string')
+            self.assertEqual(datum_field.type, 'string')
             self.assertTrue(datum_field.required)
             biosys = datum_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.DATUM_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.DATUM_TYPE_NAME)
 
             # test that we can save the dataset as returned
             self.verify_inferred_data(received)
@@ -535,10 +535,10 @@ class TestObservationSchema(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # should be an observation
-            self.assertEquals(Dataset.TYPE_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_OBSERVATION, received.get('type'))
             # data_package verification
             self.assertIn('data_package', received)
 
@@ -547,30 +547,30 @@ class TestObservationSchema(InferTestBase):
             schema = utils_data_package.GenericSchema(schema_descriptor)
             east_field = schema.get_field_by_name('Easting')
             self.assertIsNotNone(east_field)
-            self.assertEquals(east_field.type, 'number')
+            self.assertEqual(east_field.type, 'number')
             self.assertTrue(east_field.required)
             biosys = east_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.EASTING_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.EASTING_TYPE_NAME)
 
             north_field = schema.get_field_by_name('Northing')
             self.assertIsNotNone(north_field)
-            self.assertEquals(north_field.type, 'number')
+            self.assertEqual(north_field.type, 'number')
             self.assertTrue(north_field.required)
             biosys = north_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.NORTHING_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.NORTHING_TYPE_NAME)
 
             zone_field = schema.get_field_by_name('Zone')
             self.assertIsNotNone(zone_field)
-            self.assertEquals(zone_field.type, 'integer')
+            self.assertEqual(zone_field.type, 'integer')
             self.assertTrue(zone_field.required)
             biosys = zone_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.ZONE_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.ZONE_TYPE_NAME)
 
             # test that we can save the dataset as returned
             self.verify_inferred_data(received)
@@ -604,23 +604,23 @@ class TestSpeciesObservation(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # should be a species observation
-            self.assertEquals(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
             self.assertIn('data_package', received)
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
             species_name_field = schema.get_field_by_name('Species Name')
             # field attributes
             self.assertIsNotNone(species_name_field)
-            self.assertEquals(species_name_field.type, 'string')
+            self.assertEqual(species_name_field.type, 'string')
             self.assertTrue(species_name_field.required)
             # biosys type
             biosys = species_name_field.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.SPECIES_NAME_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.SPECIES_NAME_TYPE_NAME)
 
             # test that we can create a dataset with the returned data
             self.verify_inferred_data(received)
@@ -647,10 +647,10 @@ class TestSpeciesObservation(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # should be a species observation
-            self.assertEquals(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
             self.assertIn('data_package', received)
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
@@ -658,21 +658,21 @@ class TestSpeciesObservation(InferTestBase):
             # genus
             genus = schema.get_field_by_name('Genus')
             self.assertIsNotNone(genus)
-            self.assertEquals(genus.type, 'string')
+            self.assertEqual(genus.type, 'string')
             self.assertTrue(genus.required)
             biosys = genus.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.GENUS_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.GENUS_TYPE_NAME)
 
             species = schema.get_field_by_name('Species')
             self.assertIsNotNone(species)
-            self.assertEquals(species.type, 'string')
+            self.assertEqual(species.type, 'string')
             self.assertTrue(species.required)
             biosys = species.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.SPECIES_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.SPECIES_TYPE_NAME)
 
             # test that we can create a dataset with the returned data
             self.verify_inferred_data(received)
@@ -703,10 +703,10 @@ class TestSpeciesObservation(InferTestBase):
                 'file': fp,
             }
             resp = client.post(self.url, data=payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             received = resp.json()
             # should be a species observation
-            self.assertEquals(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
+            self.assertEqual(Dataset.TYPE_SPECIES_OBSERVATION, received.get('type'))
             self.assertIn('data_package', received)
             schema_descriptor = Package(received.get('data_package')).resources[0].descriptor['schema']
             schema = utils_data_package.GenericSchema(schema_descriptor)
@@ -714,39 +714,39 @@ class TestSpeciesObservation(InferTestBase):
             # genus
             genus = schema.get_field_by_name('Genus')
             self.assertIsNotNone(genus)
-            self.assertEquals(genus.type, 'string')
+            self.assertEqual(genus.type, 'string')
             self.assertTrue(genus.required)
             biosys = genus.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.GENUS_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.GENUS_TYPE_NAME)
             # species
             species = schema.get_field_by_name('Species')
             self.assertIsNotNone(species)
-            self.assertEquals(species.type, 'string')
+            self.assertEqual(species.type, 'string')
             self.assertTrue(species.required)
             biosys = species.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.SPECIES_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.SPECIES_TYPE_NAME)
             # infra rank
             infra_rank = schema.get_field_by_name('Infraspecific Rank')
             self.assertIsNotNone(infra_rank)
-            self.assertEquals(infra_rank.type, 'string')
+            self.assertEqual(infra_rank.type, 'string')
             self.assertFalse(infra_rank.required)
             biosys = infra_rank.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.INFRA_SPECIFIC_RANK_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.INFRA_SPECIFIC_RANK_TYPE_NAME)
             # infra name
             infra_name = schema.get_field_by_name('Infraspecific Name')
             self.assertIsNotNone(infra_name)
-            self.assertEquals(infra_name.type, 'string')
+            self.assertEqual(infra_name.type, 'string')
             self.assertFalse(infra_name.required)
             biosys = infra_name.get('biosys')
             self.assertIsNotNone(biosys)
             biosys_type = biosys.get('type')
-            self.assertEquals(biosys_type, BiosysSchema.INFRA_SPECIFIC_NAME_TYPE_NAME)
+            self.assertEqual(biosys_type, BiosysSchema.INFRA_SPECIFIC_NAME_TYPE_NAME)
 
             # test that we can create a dataset with the returned data
             self.verify_inferred_data(received)

--- a/biosys/apps/main/tests/api/test_serializers.py
+++ b/biosys/apps/main/tests/api/test_serializers.py
@@ -30,6 +30,6 @@ class TestDatsetSerializer(helpers.BaseUserTestCase):
         # the errors should be of the form
         # {'non_field_errors': ['The fields project, name must make a unique set.']}
         errors = ser.errors
-        self.assertEquals(['non_field_errors'], list(errors.keys()))
-        self.assertEquals(1, len(errors.get('non_field_errors')))
+        self.assertEqual(['non_field_errors'], list(errors.keys()))
+        self.assertEqual(1, len(errors.get('non_field_errors')))
         self.assertIn('A dataset with this name already exists in the project.', errors.get('non_field_errors')[0])

--- a/biosys/apps/main/tests/api/test_site.py
+++ b/biosys/apps/main/tests/api/test_site.py
@@ -378,22 +378,22 @@ class TestSiteUpload(TestCase):
         project = self.project_1
         client = self.custodian_1_client
         url = reverse('api:upload-sites', kwargs={'pk': project.pk})
-        self.assertEquals(0, Site.objects.filter(project=project).count())
+        self.assertEqual(0, Site.objects.filter(project=project).count())
         with open(csv_file) as fp:
             data = {
                 'file': fp
             }
             resp = client.post(url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             qs = Site.objects.filter(project=project)
-            self.assertEquals(len(csv_data) - 1, qs.count())
-            self.assertEquals(['C1', 'C2'], [s.code for s in qs.order_by('code')])
-            self.assertEquals(['Site 1', 'Site 2'], [s.name for s in qs.order_by('name')])
-            self.assertEquals(['Description1', 'Description2'], [s.description for s in qs.order_by('description')])
+            self.assertEqual(len(csv_data) - 1, qs.count())
+            self.assertEqual(['C1', 'C2'], [s.code for s in qs.order_by('code')])
+            self.assertEqual(['Site 1', 'Site 2'], [s.name for s in qs.order_by('name')])
+            self.assertEqual(['Description1', 'Description2'], [s.description for s in qs.order_by('description')])
 
             # test geom and attr
             s = qs.filter(code='C1').first()
-            self.assertEquals((116, -32), (s.geometry.x, s.geometry.y))
+            self.assertEqual((116, -32), (s.geometry.x, s.geometry.y))
             expected_attributes = {
                 'Latitude': '-32',
                 'Longitude': '116',
@@ -401,7 +401,7 @@ class TestSiteUpload(TestCase):
                 'Attribute1': 'attr11',
                 'Attribute2': 'attr12'}
 
-            self.assertEquals(expected_attributes, s.attributes)
+            self.assertEqual(expected_attributes, s.attributes)
 
             self.assertEqual(project.site_count, len(csv_data) - 1)
 
@@ -415,22 +415,22 @@ class TestSiteUpload(TestCase):
         project = self.project_1
         client = self.custodian_1_client
         url = reverse('api:upload-sites', kwargs={'pk': project.pk})
-        self.assertEquals(0, Site.objects.filter(project=project).count())
+        self.assertEqual(0, Site.objects.filter(project=project).count())
         with open(xlsx_file, 'rb') as fp:
             data = {
                 'file': fp
             }
             resp = client.post(url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             qs = Site.objects.filter(project=project)
-            self.assertEquals(len(csv_data) - 1, qs.count())
-            self.assertEquals(['C1', 'C2'], [s.code for s in qs.order_by('code')])
-            self.assertEquals(['Site 1', 'Site 2'], [s.name for s in qs.order_by('name')])
-            self.assertEquals(['Description1', 'Description2'], [s.description for s in qs.order_by('description')])
+            self.assertEqual(len(csv_data) - 1, qs.count())
+            self.assertEqual(['C1', 'C2'], [s.code for s in qs.order_by('code')])
+            self.assertEqual(['Site 1', 'Site 2'], [s.name for s in qs.order_by('name')])
+            self.assertEqual(['Description1', 'Description2'], [s.description for s in qs.order_by('description')])
 
             # test geom and attr
             s = qs.filter(code='C1').first()
-            self.assertEquals((116, -32), (s.geometry.x, s.geometry.y))
+            self.assertEqual((116, -32), (s.geometry.x, s.geometry.y))
             expected_attributes = {
                 'Latitude': '-32',
                 'Longitude': '116',
@@ -438,7 +438,7 @@ class TestSiteUpload(TestCase):
                 'Attribute1': 'attr11',
                 'Attribute2': 'attr12'}
 
-            self.assertEquals(expected_attributes, s.attributes)
+            self.assertEqual(expected_attributes, s.attributes)
 
             self.assertEqual(project.site_count, len(csv_data) - 1)
 
@@ -451,19 +451,19 @@ class TestSiteUpload(TestCase):
         project = self.project_1
         client = self.custodian_1_client
         url = reverse('api:upload-sites', kwargs={'pk': project.pk})
-        self.assertEquals(0, Site.objects.filter(project=project).count())
+        self.assertEqual(0, Site.objects.filter(project=project).count())
         with open(xlsx_file, 'rb') as fp:
             data = {
                 'file': fp
             }
             resp = client.post(url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             qs = Site.objects.filter(project=project)
-            self.assertEquals(qs.count(), 1)
+            self.assertEqual(qs.count(), 1)
             site = qs.first()
-            self.assertEquals(site.code, 'C1')
+            self.assertEqual(site.code, 'C1')
             self.assertEqual(site.name, 'Site 1')
-            self.assertEquals(site.description, 'Description1')
+            self.assertEqual(site.description, 'Description1')
 
             # test geom and attr
             self.assertAlmostEqual(site.geometry.x, 116, places=4)
@@ -476,7 +476,7 @@ class TestSiteUpload(TestCase):
                 'Attribute1': 'attr11',
                 'Attribute2': 'attr12'}
 
-            self.assertEquals(expected_attributes, site.attributes)
+            self.assertEqual(expected_attributes, site.attributes)
 
     def test_site_code_column_name(self):
         """
@@ -491,16 +491,16 @@ class TestSiteUpload(TestCase):
         project = self.project_1
         client = self.custodian_1_client
         url = reverse('api:upload-sites', kwargs={'pk': project.pk})
-        self.assertEquals(0, Site.objects.filter(project=project).count())
+        self.assertEqual(0, Site.objects.filter(project=project).count())
         with open(csv_file) as fp:
             data = {
                 'file': fp
             }
             resp = client.post(url, data=data, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             qs = Site.objects.filter(project=project)
-            self.assertEquals(len(csv_data) - 1, qs.count())
-            self.assertEquals(['C1', 'C2'], [s.code for s in qs.order_by('code')])
+            self.assertEqual(len(csv_data) - 1, qs.count())
+            self.assertEqual(['C1', 'C2'], [s.code for s in qs.order_by('code')])
 
 
 class TestSerialization(helpers.BaseUserTestCase):

--- a/biosys/apps/main/tests/api/test_species_observation.py
+++ b/biosys/apps/main/tests/api/test_species_observation.py
@@ -359,7 +359,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
 
     def test_empty_not_allowed(self):
         ds = self.ds_1
@@ -374,7 +374,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
 
     def test_create_column_not_in_schema(self):
         """
@@ -399,7 +399,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
             client.post(url, data=payload, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), 0)
+        self.assertEqual(ds.record_queryset.count(), 0)
 
     def test_update_column_not_in_schema(self):
         """
@@ -423,12 +423,12 @@ class TestDataValidation(helpers.BaseUserTestCase):
             client.put(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
         self.assertEqual(
             client.patch(url, data, format='json').status_code,
             status.HTTP_400_BAD_REQUEST
         )
-        self.assertEquals(ds.record_queryset.count(), count)
+        self.assertEqual(ds.record_queryset.count(), count)
 
     def test_date_error(self):
         """
@@ -454,7 +454,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.post(url_post, data, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), count + 1)
+            self.assertEqual(ds.record_queryset.count(), count + 1)
 
         invalid_values = [None, '', 'not a date']
         for value in invalid_values:
@@ -478,7 +478,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.patch(url_update, data, format='json').status_code,
                 status.HTTP_400_BAD_REQUEST
             )
-            self.assertEquals(ds.record_queryset.count(), count)
+            self.assertEqual(ds.record_queryset.count(), count)
 
     def test_geometry_error(self):
         """
@@ -504,7 +504,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.post(url_post, data, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), count + 1)
+            self.assertEqual(ds.record_queryset.count(), count + 1)
 
         invalid_values = [None, '', 'not a valid latitude']
         for value in invalid_values:
@@ -528,7 +528,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.patch(url_update, data, format='json').status_code,
                 status.HTTP_400_BAD_REQUEST
             )
-            self.assertEquals(ds.record_queryset.count(), count)
+            self.assertEqual(ds.record_queryset.count(), count)
 
     def test_species_name(self):
         ds = self.ds_1
@@ -550,7 +550,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.post(url_post, data, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), count + 1)
+            self.assertEqual(ds.record_queryset.count(), count + 1)
 
         invalid_values = [None, '', 125]
         for value in invalid_values:
@@ -574,7 +574,7 @@ class TestDataValidation(helpers.BaseUserTestCase):
                 client.patch(url_update, data, format='json').status_code,
                 status.HTTP_400_BAD_REQUEST
             )
-            self.assertEquals(ds.record_queryset.count(), count)
+            self.assertEqual(ds.record_queryset.count(), count)
 
 
 class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
@@ -634,7 +634,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
 
         # clear all records
         ds.record_queryset.delete()
-        self.assertEquals(ds.record_queryset.count(), 0)
+        self.assertEqual(ds.record_queryset.count(), 0)
         payload = {
             "dataset": ds.pk,
             "data": data
@@ -644,13 +644,13 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.post(url, data=payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
         expected_date = datetime.date(2018, 1, 31)
-        self.assertEquals(timezone.localtime(record.datetime).date(), expected_date)
+        self.assertEqual(timezone.localtime(record.datetime).date(), expected_date)
         geometry = record.geometry
         self.assertIsInstance(geometry, Point)
-        self.assertEquals((115.75, -32.0), (geometry.x, geometry.y))
+        self.assertEqual((115.75, -32.0), (geometry.x, geometry.y))
 
     def test_update(self):
         """
@@ -670,7 +670,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
 
         # clear all records
         ds.record_queryset.delete()
-        self.assertEquals(ds.record_queryset.count(), 0)
+        self.assertEqual(ds.record_queryset.count(), 0)
         payload = {
             "dataset": ds.pk,
             "data": data
@@ -680,7 +680,7 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
             client.post(url, data=payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
         # date and lat/lon
         # change lat/lon
@@ -700,10 +700,10 @@ class TestDateTimeAndGeometryExtraction(helpers.BaseUserTestCase):
         )
         record.refresh_from_db()
         expected_date = datetime.date(2017, 12, 24)
-        self.assertEquals(timezone.localtime(record.datetime).date(), expected_date)
+        self.assertEqual(timezone.localtime(record.datetime).date(), expected_date)
         geometry = record.geometry
         self.assertIsInstance(geometry, Point)
-        self.assertEquals((111.111, 22.222), (geometry.x, geometry.y))
+        self.assertEqual((111.111, 22.222), (geometry.x, geometry.y))
 
 
 class TestSpeciesNameExtraction(helpers.BaseUserTestCase):
@@ -762,7 +762,7 @@ class TestSpeciesNameExtraction(helpers.BaseUserTestCase):
 
         # clear all records
         ds.record_queryset.delete()
-        self.assertEquals(ds.record_queryset.count(), 0)
+        self.assertEqual(ds.record_queryset.count(), 0)
         payload = {
             "dataset": ds.pk,
             "data": data
@@ -772,8 +772,8 @@ class TestSpeciesNameExtraction(helpers.BaseUserTestCase):
             client.post(url, data=payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
-        self.assertEquals(ds.record_queryset.first().species_name, 'Chubby Bat')
+        self.assertEqual(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.first().species_name, 'Chubby Bat')
 
     def test_update(self):
         """
@@ -798,9 +798,9 @@ class TestSpeciesNameExtraction(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
-        self.assertEquals(record.species_name, 'Chubby Bat')
+        self.assertEqual(record.species_name, 'Chubby Bat')
 
         # update the species_name
         data = {
@@ -844,9 +844,9 @@ class TestSpeciesNameExtraction(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
-        self.assertEquals(record.species_name, 'Chubby Bat')
+        self.assertEqual(record.species_name, 'Chubby Bat')
 
         # update the species_name
         data = {
@@ -926,7 +926,7 @@ class TestNameIDFromSpeciesName(helpers.BaseUserTestCase):
         }
         for species_name, name_id in list(helpers.LightSpeciesFacade().name_id_by_species_name().items())[:2]:
             ds.record_queryset.delete()
-            self.assertEquals(ds.record_queryset.count(), 0)
+            self.assertEqual(ds.record_queryset.count(), 0)
             data['Species Name'] = species_name
             payload = {
                 "dataset": ds.pk,
@@ -937,8 +937,8 @@ class TestNameIDFromSpeciesName(helpers.BaseUserTestCase):
                 client.post(url, payload, format='json').status_code,
                 status.HTTP_201_CREATED
             )
-            self.assertEquals(ds.record_queryset.count(), 1)
-            self.assertEquals(ds.record_queryset.first().name_id, name_id)
+            self.assertEqual(ds.record_queryset.count(), 1)
+            self.assertEqual(ds.record_queryset.first().name_id, name_id)
 
     def test_update(self):
         """
@@ -964,9 +964,9 @@ class TestNameIDFromSpeciesName(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
-        self.assertEquals(record.name_id, -1)
+        self.assertEqual(record.name_id, -1)
 
         # update the species_name
         data = {
@@ -1012,9 +1012,9 @@ class TestNameIDFromSpeciesName(helpers.BaseUserTestCase):
             client.post(url, payload, format='json').status_code,
             status.HTTP_201_CREATED
         )
-        self.assertEquals(ds.record_queryset.count(), 1)
+        self.assertEqual(ds.record_queryset.count(), 1)
         record = ds.record_queryset.first()
-        self.assertEquals(record.name_id, -1)
+        self.assertEqual(record.name_id, -1)
 
         # update the species_name
         data = {
@@ -1069,7 +1069,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         # check headers
         self.assertEqual(resp.get('content-type'),
                          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
@@ -1079,22 +1079,22 @@ class TestExport(helpers.BaseUserTestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
+        self.assertEqual(ext, '.xlsx')
         filename.startswith(dataset.name)
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(dataset.name, sheet_names[0])
-        ws = wb.get_sheet_by_name(dataset.name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(dataset.name, sheet_names[0])
+        ws = wb[dataset.name]
         rows = list(ws.rows)
         expected_records = Record.objects.filter(dataset=dataset)
-        self.assertEquals(len(rows), expected_records.count() + 1)
+        self.assertEqual(len(rows), expected_records.count() + 1)
         headers = [c.value for c in rows[0]]
         schema = dataset.schema
         # all the columns of the schema should be in the excel
-        self.assertEquals(schema.headers, headers)
+        self.assertEqual(schema.headers, headers)
 
     def test_permission_ok_for_not_custodian(self):
         """Export is a read action. Should be authorised for every logged-in user."""
@@ -1109,7 +1109,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
     def test_permission_denied_if_not_logged_in(self):
         """Must be logged-in."""
@@ -1124,7 +1124,7 @@ class TestExport(helpers.BaseUserTestCase):
             resp = client.get(url, query)
         except Exception as e:
             self.fail("Export should not raise an exception: {}".format(e))
-        self.assertEquals(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestSpeciesNameFromNameID(helpers.BaseUserTestCase):
@@ -1191,16 +1191,16 @@ class TestSpeciesNameFromNameID(helpers.BaseUserTestCase):
             ['24204', '02/02/2017', -33.0, 116.0]  # "Vespadelus douglasorum"
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), len(csv_data) - 1)
+            self.assertEqual(records.count(), len(csv_data) - 1)
             for r in records:
                 self.assertTrue(r.name_id > 0)
                 self.assertIsNotNone(r.species_name)
@@ -1299,17 +1299,17 @@ class TestSpeciesNameFromNameID(helpers.BaseUserTestCase):
             ['24204', '02/02/2017', -33.0, 116.0]  # "Vespadelus douglasorum"
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, payload, format='multipart')
-            self.assertEquals(status.HTTP_400_BAD_REQUEST, resp.status_code)
+            self.assertEqual(status.HTTP_400_BAD_REQUEST, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
             # should be only one record (the good one)
-            self.assertEquals(records.count(), 1)
+            self.assertEqual(records.count(), 1)
             vespadelus = records.filter(name_id=24204).first()
             self.assertIsNotNone(vespadelus)
             self.assertEqual(vespadelus.species_name, "Vespadelus douglasorum")
@@ -1405,16 +1405,16 @@ class TestSpeciesNameAndNameID(helpers.BaseUserTestCase):
             ['24204', 'French Frog', '02/02/2017', -33.0, 116.0]  # "Vespadelus douglasorum"
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), len(csv_data) - 1)
+            self.assertEqual(records.count(), len(csv_data) - 1)
             for r in records:
                 self.assertTrue(r.name_id > 0)
                 self.assertIsNotNone(r.species_name)
@@ -1442,16 +1442,16 @@ class TestSpeciesNameAndNameID(helpers.BaseUserTestCase):
             ['', 'Vespadelus douglasorum', '02/02/2017', -33.0, 116.0]  # "Vespadelus douglasorum"
         ]
         file_ = helpers.rows_to_xlsx_file(csv_data)
-        self.assertEquals(0, Record.objects.filter(dataset=dataset).count())
+        self.assertEqual(0, Record.objects.filter(dataset=dataset).count())
         url = reverse('api:dataset-upload', kwargs={'pk': dataset.pk})
         with open(file_, 'rb') as fp:
             payload = {
                 'file': fp
             }
             resp = client.post(url, payload, format='multipart')
-            self.assertEquals(status.HTTP_200_OK, resp.status_code)
+            self.assertEqual(status.HTTP_200_OK, resp.status_code)
             records = Record.objects.filter(dataset=dataset)
-            self.assertEquals(records.count(), len(csv_data) - 1)
+            self.assertEqual(records.count(), len(csv_data) - 1)
             for r in records:
                 self.assertTrue(r.name_id > 0)
                 self.assertIsNotNone(r.species_name)
@@ -1654,12 +1654,12 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             ['Canis', 'lupus', '2018-01-25', -32.0, 115.75],
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         received = resp.json()
         rec_id = received[0]['recordId']
         record = Record.objects.filter(pk=rec_id).first()
-        self.assertEquals(record.species_name, 'Canis lupus')
-        self.assertEquals(record.name_id, 25454)
+        self.assertEqual(record.species_name, 'Canis lupus')
+        self.assertEqual(record.name_id, 25454)
 
     def test_genus_species_and_infra_specifics_happy_path(self):
         schema = self.schema_with_4_columns_genus()
@@ -1669,13 +1669,13 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             ['Canis', 'lupus', 'subsp. familiaris ', ' rank naughty dog ', '2018-01-25', -32.0, 115.75],
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk)
-        self.assertEquals(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
         received = resp.json()
         rec_id = received[0]['recordId']
         record = Record.objects.filter(pk=rec_id).first()
         expected_species_name = 'Canis lupus subsp. familiaris rank naughty dog'
-        self.assertEquals(record.species_name, expected_species_name)
-        self.assertEquals(record.name_id, -1)
+        self.assertEqual(record.species_name, expected_species_name)
+        self.assertEqual(record.name_id, -1)
 
     def test_validation_missing_species(self):
         schema = self.schema_with_2_columns_genus()
@@ -1692,13 +1692,13 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             'data': data
         }
         resp = self.client.post(url, payload, format='json')
-        self.assertEquals(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         received_json = resp.json()
         # should contain one error on the 'data' for the species field
         self.assertIn('data', received_json)
         errors = received_json.get('data')
         self.assertIsInstance(errors, list)
-        self.assertEquals(len(errors), 1)
+        self.assertEqual(len(errors), 1)
         error = errors[0]
         # should be "Species::msg"
         pattern = re.compile(r"^Species::(.+)$")
@@ -1723,11 +1723,11 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             ['  ', 'lupus', '2018-01-25', -32.0, 115.75]
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk, strict=False)
-        self.assertEquals(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         received = resp.json()
         # expected: array of report by row
         self.assertIsInstance(received, list)
-        self.assertEquals(len(received), 3)
+        self.assertEqual(len(received), 3)
         # this what an report should look like
         expected_row_report = {
             'row': 3,
@@ -1738,7 +1738,7 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             errors = row_report.get('errors')
             self.assertIn('Genus', errors)
             msg = errors.get('Genus')
-            self.assertEquals(msg, expected_row_report['errors']['Genus'])
+            self.assertEqual(msg, expected_row_report['errors']['Genus'])
 
     def test_species_required_error(self):
         """
@@ -1759,11 +1759,11 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             ['Canis', '   ', '2018-01-25', -32.0, 115.75]
         ]
         resp = self._upload_records_from_rows(records, dataset_pk=dataset.pk, strict=False)
-        self.assertEquals(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
         received = resp.json()
         # expected: array of report by row
         self.assertIsInstance(received, list)
-        self.assertEquals(len(received), 3)
+        self.assertEqual(len(received), 3)
         # this what an report should look like
         expected_row_report = {
             'row': 3,
@@ -1774,7 +1774,7 @@ class TestCompositeSpeciesName(helpers.BaseUserTestCase):
             errors = row_report.get('errors')
             self.assertIn('Species', errors)
             msg = errors.get('Species')
-            self.assertEquals(msg, expected_row_report['errors']['Species'])
+            self.assertEqual(msg, expected_row_report['errors']['Species'])
 
 
 class TestPatch(helpers.BaseUserTestCase):

--- a/biosys/apps/main/tests/api/test_species_observation.py
+++ b/biosys/apps/main/tests/api/test_species_observation.py
@@ -1084,7 +1084,7 @@ class TestExport(helpers.BaseUserTestCase):
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named from dataset
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(dataset.name, sheet_names[0])
         ws = wb[dataset.name]

--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -176,8 +176,8 @@ class TestSchemaConstraints(TestCase):
         """
         None or empty is accepted
         """
-        self.assertEquals({}, SchemaConstraints(None).descriptor)
-        self.assertEquals({}, SchemaConstraints({}).descriptor)
+        self.assertEqual({}, SchemaConstraints(None).descriptor)
+        self.assertEqual({}, SchemaConstraints({}).descriptor)
 
     def test_required_property(self):
         # no constraints -> require = False
@@ -198,10 +198,10 @@ class TestSchemaConstraints(TestCase):
         cts = clone(BASE_CONSTRAINTS)
         sch = SchemaConstraints(cts)
         self.assertTrue(hasattr(sch, 'get'))
-        self.assertEquals(cts.get('required'), sch.get('required'))
-        self.assertEquals(cts.get('constraints'), sch.get('constraints'))
-        self.assertEquals(None, sch.get('bad_keys'))
-        self.assertEquals('default', sch.get('bad_keys', 'default'))
+        self.assertEqual(cts.get('required'), sch.get('required'))
+        self.assertEqual(cts.get('constraints'), sch.get('constraints'))
+        self.assertEqual(None, sch.get('bad_keys'))
+        self.assertEqual('default', sch.get('bad_keys', 'default'))
 
 
 class TestSchemaField(TestCase):
@@ -229,10 +229,10 @@ class TestSchemaField(TestCase):
         field = self.base_field
         sch = SchemaField(field)
         self.assertTrue(hasattr(sch, 'get'))
-        self.assertEquals(field.get('Name'), sch.get('Name'))
-        self.assertEquals(field.get('constraints'), sch.get('constraints'))
-        self.assertEquals(None, sch.get('bad_keys'))
-        self.assertEquals('default', sch.get('bad_keys', 'default'))
+        self.assertEqual(field.get('Name'), sch.get('Name'))
+        self.assertEqual(field.get('constraints'), sch.get('constraints'))
+        self.assertEqual(None, sch.get('bad_keys'))
+        self.assertEqual('default', sch.get('bad_keys', 'default'))
 
     def test_column_name(self):
         """
@@ -240,7 +240,7 @@ class TestSchemaField(TestCase):
         """
         field = self.base_field
         sch = SchemaField(field)
-        self.assertEquals(sch.name, sch.column_name)
+        self.assertEqual(sch.name, sch.column_name)
         self.assertNotEqual(sch.column_name, sch.title)
 
     def test_constraints(self):
@@ -255,12 +255,12 @@ class TestSchemaField(TestCase):
         """
         field = self.base_field
         self.assertFalse(field.get('aliases'))
-        self.assertEquals([], SchemaField(field).aliases)
+        self.assertEqual([], SchemaField(field).aliases)
         field['aliases'] = []
-        self.assertEquals([], SchemaField(field).aliases)
+        self.assertEqual([], SchemaField(field).aliases)
         field['aliases'] = ['alias1', 'Alias2']
         sch = SchemaField(field)
-        self.assertEquals(field['aliases'], sch.aliases)
+        self.assertEqual(field['aliases'], sch.aliases)
         # test some related method
         self.assertTrue(sch.has_alias('alias1'))
         self.assertTrue(sch.has_alias('Alias2'))
@@ -466,8 +466,8 @@ class TestObservationSchemaCast(TestCase):
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, GEOSGeometry))
         self.assertTrue(isinstance(point, Point))
-        self.assertEquals((115.3, -32), point.coords)
-        self.assertEquals(MODEL_SRID, point.get_srid())
+        self.assertEqual((115.3, -32), point.coords)
+        self.assertEqual(MODEL_SRID, point.get_srid())
 
     def test_cast_point_with_datum(self):
         """
@@ -485,9 +485,9 @@ class TestObservationSchemaCast(TestCase):
         point = schema.cast_geometry(record)
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, Point))
-        self.assertEquals((115.3, -32), point.coords)
+        self.assertEqual((115.3, -32), point.coords)
         expected_srid = get_datum_srid(record['Datum'])
-        self.assertEquals(expected_srid, point.get_srid())
+        self.assertEqual(expected_srid, point.get_srid())
 
     def test_cast_point_with_invalid_datum(self):
         """
@@ -526,8 +526,8 @@ class TestObservationSchemaCast(TestCase):
         point = schema.cast_geometry(record)
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, Point))
-        self.assertEquals((easting, northing), point.coords)
-        self.assertEquals(get_datum_srid(datum), point.get_srid())
+        self.assertEqual((easting, northing), point.coords)
+        self.assertEqual(get_datum_srid(datum), point.get_srid())
 
         # create a db record with geometry = east/north and check geometry conversion
         # create dataset
@@ -579,8 +579,8 @@ class TestObservationSchemaCast(TestCase):
         point = schema.cast_geometry(record)
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, Point))
-        self.assertEquals((easting, northing), point.coords)
-        self.assertEquals(expected_srid, point.get_srid())
+        self.assertEqual((easting, northing), point.coords)
+        self.assertEqual(expected_srid, point.get_srid())
 
         # create a db record with geometry = east/north and check geometry conversion
         # create dataset

--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -467,7 +467,7 @@ class TestObservationSchemaCast(TestCase):
         self.assertTrue(isinstance(point, GEOSGeometry))
         self.assertTrue(isinstance(point, Point))
         self.assertEqual((115.3, -32), point.coords)
-        self.assertEqual(MODEL_SRID, point.get_srid())
+        self.assertEqual(MODEL_SRID, point.srid)
 
     def test_cast_point_with_datum(self):
         """
@@ -487,7 +487,7 @@ class TestObservationSchemaCast(TestCase):
         self.assertTrue(isinstance(point, Point))
         self.assertEqual((115.3, -32), point.coords)
         expected_srid = get_datum_srid(record['Datum'])
-        self.assertEqual(expected_srid, point.get_srid())
+        self.assertEqual(expected_srid, point.srid)
 
     def test_cast_point_with_invalid_datum(self):
         """
@@ -527,7 +527,7 @@ class TestObservationSchemaCast(TestCase):
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, Point))
         self.assertEqual((easting, northing), point.coords)
-        self.assertEqual(get_datum_srid(datum), point.get_srid())
+        self.assertEqual(get_datum_srid(datum), point.srid)
 
         # create a db record with geometry = east/north and check geometry conversion
         # create dataset
@@ -545,7 +545,7 @@ class TestObservationSchemaCast(TestCase):
             geometry=point,
             data=record)
         record.refresh_from_db()
-        self.assertEqual(MODEL_SRID, record.geometry.get_srid())
+        self.assertEqual(MODEL_SRID, record.geometry.srid)
         self.assertEqual((116, -31), (int(record.geometry.x), int(record.geometry.y)))
 
     def test_cast_point_easting_northing_with_zone_field(self):
@@ -580,7 +580,7 @@ class TestObservationSchemaCast(TestCase):
         self.assertIsNotNone(point)
         self.assertTrue(isinstance(point, Point))
         self.assertEqual((easting, northing), point.coords)
-        self.assertEqual(expected_srid, point.get_srid())
+        self.assertEqual(expected_srid, point.srid)
 
         # create a db record with geometry = east/north and check geometry conversion
         # create dataset
@@ -598,7 +598,7 @@ class TestObservationSchemaCast(TestCase):
             geometry=point,
             data=record)
         record.refresh_from_db()
-        self.assertEqual(MODEL_SRID, record.geometry.get_srid())
+        self.assertEqual(MODEL_SRID, record.geometry.srid)
         self.assertEqual((116, -31), (int(record.geometry.x), int(record.geometry.y)))
 
 

--- a/biosys/apps/main/tests/test_download_templates.py
+++ b/biosys/apps/main/tests/test_download_templates.py
@@ -29,19 +29,19 @@ class TestDownloadSiteTemplates(TestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
-        self.assertEquals(filename, 'Sites_template_lat_long')
+        self.assertEqual(ext, '.xlsx')
+        self.assertEqual(filename, 'Sites_template_lat_long')
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named 'Sites'
         expected_sheet_name = 'Sites'
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(sheet_names[0], expected_sheet_name)
-        ws = wb.get_sheet_by_name(expected_sheet_name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(sheet_names[0], expected_sheet_name)
+        ws = wb[expected_sheet_name]
         rows = list(ws.rows)
         # only one row
-        self.assertEquals(len(rows), 1)
+        self.assertEqual(len(rows), 1)
         got_headers = [c.value for c in rows[0]]
         expected_headers = ['Name', 'Code', 'Description', 'Latitude', 'Longitude', 'Datum']
         self.assertEqual(got_headers, expected_headers)
@@ -63,19 +63,19 @@ class TestDownloadSiteTemplates(TestCase):
         match = re.match('attachment; filename=(.+)', content_disposition)
         self.assertIsNotNone(match)
         filename, ext = path.splitext(match.group(1))
-        self.assertEquals(ext, '.xlsx')
-        self.assertEquals(filename, 'Sites_template_easting_northing')
+        self.assertEqual(ext, '.xlsx')
+        self.assertEqual(filename, 'Sites_template_easting_northing')
         # read content
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named 'Sites'
         expected_sheet_name = 'Sites'
         sheet_names = wb.get_sheet_names()
-        self.assertEquals(1, len(sheet_names))
-        self.assertEquals(sheet_names[0], expected_sheet_name)
-        ws = wb.get_sheet_by_name(expected_sheet_name)
+        self.assertEqual(1, len(sheet_names))
+        self.assertEqual(sheet_names[0], expected_sheet_name)
+        ws = wb[expected_sheet_name]
         rows = list(ws.rows)
         # only one row
-        self.assertEquals(len(rows), 1)
+        self.assertEqual(len(rows), 1)
         got_headers = [c.value for c in rows[0]]
         expected_headers = ['Name', 'Code', 'Description', 'Easting', 'Northing', 'Datum', 'Zone']
         self.assertEqual(got_headers, expected_headers)

--- a/biosys/apps/main/tests/test_download_templates.py
+++ b/biosys/apps/main/tests/test_download_templates.py
@@ -35,7 +35,7 @@ class TestDownloadSiteTemplates(TestCase):
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named 'Sites'
         expected_sheet_name = 'Sites'
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(sheet_names[0], expected_sheet_name)
         ws = wb[expected_sheet_name]
@@ -69,7 +69,7 @@ class TestDownloadSiteTemplates(TestCase):
         wb = load_workbook(six.BytesIO(resp.content), read_only=True)
         # one datasheet named 'Sites'
         expected_sheet_name = 'Sites'
-        sheet_names = wb.get_sheet_names()
+        sheet_names = wb.sheetnames
         self.assertEqual(1, len(sheet_names))
         self.assertEqual(sheet_names[0], expected_sheet_name)
         ws = wb[expected_sheet_name]

--- a/biosys/apps/main/tests/test_schema_species_name_parser.py
+++ b/biosys/apps/main/tests/test_schema_species_name_parser.py
@@ -23,13 +23,13 @@ class TestSpeciesNameOnly(TestCase):
         self.assertTrue(parser.valid)
         self.assertTrue(parser.has_species_name)
         self.assertTrue(parser.is_species_name_only)
-        self.assertEquals(parser.species_name_field.name, 'Species Name')
+        self.assertEqual(parser.species_name_field.name, 'Species Name')
         expected_species_name = 'Canis Lupus'
         data = {
             'Species Name': ' Canis Lupus  '
         }
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
     def test_species_name_only_with_biosys_type(self):
         """
@@ -64,7 +64,7 @@ class TestSpeciesNameOnly(TestCase):
             'Species': ' Canis Lupus  '
         }
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
     def test_must_be_required1(self):
         """
@@ -78,7 +78,7 @@ class TestSpeciesNameOnly(TestCase):
         descriptor['fields'].append(field_desc)
         parser = SpeciesNameParser(descriptor)
         self.assertFalse(parser.valid)
-        self.assertEquals(len(parser.errors), 1)
+        self.assertEqual(len(parser.errors), 1)
         error = parser.errors[0]
         self.assertIn('Species Name', error)
         self.assertIn('required', error)
@@ -105,7 +105,7 @@ class TestSpeciesNameOnly(TestCase):
         descriptor['fields'].append(field_desc)
         parser = SpeciesNameParser(descriptor)
         self.assertFalse(parser.valid)
-        self.assertEquals(len(parser.errors), 1)
+        self.assertEqual(len(parser.errors), 1)
         error = parser.errors[0]
         self.assertIn('Species', error)
         self.assertIn('required', error)
@@ -150,7 +150,7 @@ class TestSpeciesNameOnly(TestCase):
             'Species Name': 'Chubby Bat'
         }
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
     def test_two_biosys_type_is_error(self):
         """
@@ -229,16 +229,16 @@ class TestGenusAndSpecies(TestCase):
         self.assertTrue(parser.has_genus_and_species)
         self.assertTrue(parser.is_genus_and_species_only)
         self.assertIsNotNone(parser.genus_field)
-        self.assertEquals(parser.genus_field.name, 'Genus')
+        self.assertEqual(parser.genus_field.name, 'Genus')
         self.assertIsNotNone(parser.species_field)
-        self.assertEquals(parser.species_field.name, 'Species')
+        self.assertEqual(parser.species_field.name, 'Species')
         expected_species_name = 'Canis Lupus'
         data = {
             'Genus': ' Canis ',
             'Species': ' Lupus '
         }
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
     def test_genus_species_and_infra_specific(self):
         fields = [
@@ -272,13 +272,13 @@ class TestGenusAndSpecies(TestCase):
         self.assertTrue(parser.has_genus_and_species)
         self.assertTrue(parser.is_genus_and_species_only)
         self.assertIsNotNone(parser.genus_field)
-        self.assertEquals(parser.genus_field.name, 'Genus')
+        self.assertEqual(parser.genus_field.name, 'Genus')
         self.assertIsNotNone(parser.species_field)
-        self.assertEquals(parser.species_field.name, 'Species')
+        self.assertEqual(parser.species_field.name, 'Species')
         self.assertIsNotNone(parser.infra_rank_field)
-        self.assertEquals(parser.infra_rank_field.name, 'InfraSpecific rank')
+        self.assertEqual(parser.infra_rank_field.name, 'InfraSpecific rank')
         self.assertIsNotNone(parser.infra_name_field)
-        self.assertEquals(parser.infra_name_field.name, 'InfraSpecific Name')
+        self.assertEqual(parser.infra_name_field.name, 'InfraSpecific Name')
         data = {
             'Genus': ' Canis ',
             'Species': ' Lupus ',
@@ -288,7 +288,7 @@ class TestGenusAndSpecies(TestCase):
         # expect: genus + species + infra_rank + infra_name
         expected_species_name = 'Canis Lupus subsp. familiaris more stuff'
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
         data = {
             'Genus': ' Canis ',
@@ -299,7 +299,7 @@ class TestGenusAndSpecies(TestCase):
         # expect: genus + species + infra_rank + infra_name
         expected_species_name = 'Canis Lupus subsp. familiaris'
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)
 
         data = {
             'Genus': ' Canis ',
@@ -310,4 +310,4 @@ class TestGenusAndSpecies(TestCase):
         # expect: genus + species + infra_rank + infra_name
         expected_species_name = 'Canis Lupus infra name'
         casted_value = parser.cast_species_name(data)
-        self.assertEquals(expected_species_name, casted_value)
+        self.assertEqual(expected_species_name, casted_value)

--- a/biosys/apps/main/urls.py
+++ b/biosys/apps/main/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from main import views as main_views
 
-download_urlpatterns = [
+download_urlpatterns = ([
     url(r'templates/site/lat-long/?',
         main_views.SiteTemplateView.as_view(model='lat_long'),
         name="site-template-lat-long"
@@ -11,4 +11,4 @@ download_urlpatterns = [
         main_views.SiteTemplateView.as_view(model='easting_northing'),
         name="site-template-easting-northing"
         ),
-]
+], 'download')

--- a/biosys/apps/publish/urls.py
+++ b/biosys/apps/publish/urls.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import, unicode_literals, print_function, divisi
 from django.conf.urls import url
 from apps.publish.views import data_view, export
 
-urlpatterns = [
+publish_urlpatterns = ([
     url(r'^$', data_view.DataView.as_view(), name='data_view'),
     url(r'^data/(?P<pk>\d+)/?$', data_view.JSONDataTableView.as_view(), name='data_json'),
     url(r'^export/(?P<pk>\d+)/?$', export.ExportDataSetView.as_view(), name='data_export'),
     url(r'^export-template/(?P<pk>\d+)/?$', export.ExportTemplateView.as_view(), name='data_export_template')
-]
+], 'publish')

--- a/biosys/urls.py
+++ b/biosys/urls.py
@@ -14,6 +14,7 @@ from drf_yasg import openapi
 from main.views import DashboardView
 from main.api.urls import urls as api_endpoints
 from main.urls import download_urlpatterns
+from publish.urls import publish_urlpatterns
 
 
 def home_view_selection_view(request):
@@ -42,8 +43,8 @@ web_urls = [
     url(r'^admin/logout/$', auth_views.logout, {'next_page': '/'}),
     # use a function to determine where admin/ will resolve to, based on the user
     url(r'^admin/$', admin_view_selection_view),
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'^publish/', include('publish.urls', namespace='publish')),
+    url(r'^admin/', admin.site.urls),
+    url(r'^publish/', include(publish_urlpatterns, namespace='publish')),
     url(r'^$', home_view_selection_view, name='home'),
     url(r'^dashboard/', login_required(DashboardView.as_view()), name='dashboard'),
     url(r'^about/', TemplateView.as_view(template_name='main/about.html'), name='about'),

--- a/biosys/urls.py
+++ b/biosys/urls.py
@@ -17,7 +17,7 @@ from main.urls import download_urlpatterns
 
 
 def home_view_selection_view(request):
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('api/explorer')
     else:
         return redirect('login')
@@ -26,7 +26,7 @@ def home_view_selection_view(request):
 def admin_view_selection_view(request):
     if request.user.is_superuser:
         return admin.site.index(request)
-    elif request.user.is_authenticated():
+    elif request.user.is_authenticated:
         return redirect('dashboard')
     else:
         return redirect('login')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Django>=1.11,<2.0
 psycopg2-binary==2.7.4
 django-confy==1.0.4
 django-bootstrap3==10.0.1
-django-auth-ldap==1.2.8
 openpyxl==2.4.2
 django-reversion==1.10
 pytz>=2016.6.1


### PR DESCRIPTION
* Most of changes are about tests: `assertEquals` -> `assertEqual`
* Django url patterns with app_name (mandatory for django 2.0)
* Some openpyxl deprecation warnings
* Removed dependency django-ldap