### PR TITLE
Fix warning error from the wsgi about not finding biosys/biosys/.env.

### DIFF
--- a/biosys/wsgi.py
+++ b/biosys/wsgi.py
@@ -9,6 +9,10 @@ import confy
 from django.core.wsgi import get_wsgi_application
 from dj_static import Cling, MediaCling
 
-confy.read_environment_file(confy.env('ENV_FILE'))
+if confy.env('ENV_FILE') is not None:
+    confy.read_environment_file(confy.env('ENV_FILE'))
+else:
+    confy.read_environment_file(".env")
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "biosys.settings")
 application = Cling(MediaCling(get_wsgi_application()))


### PR DESCRIPTION
Passing None to confy.read_environment_file will result in a wrong path detection.