### PR TITLE
Proxy settings as environment variables

### DIFF
--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -366,4 +366,6 @@ S3_USE_SIGV4 = True
 # By default it is s3.<region>.amazonaws.com/<bucket>/...
 AWS_S3_CUSTOM_DOMAIN = env('AWS_S3_CUSTOM_DOMAIN', None)
 
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# For when the app is behind a proxy or a load balancer in charge of the https/ssl
+# https://docs.djangoproject.com/en/2.1/ref/settings/#secure-proxy-ssl-header
+SECURE_PROXY_SSL_HEADER = env('SECURE_PROXY_SSL_HEADER')

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -365,3 +365,5 @@ S3_USE_SIGV4 = True
 # If using a CDN or a S3 static website tell django-storages the domain to use to refer to static files.
 # By default it is s3.<region>.amazonaws.com/<bucket>/...
 AWS_S3_CUSTOM_DOMAIN = env('AWS_S3_CUSTOM_DOMAIN', None)
+
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -369,3 +369,4 @@ AWS_S3_CUSTOM_DOMAIN = env('AWS_S3_CUSTOM_DOMAIN', None)
 # For when the app is behind a proxy or a load balancer in charge of the https/ssl
 # https://docs.djangoproject.com/en/2.1/ref/settings/#secure-proxy-ssl-header
 SECURE_PROXY_SSL_HEADER = env('SECURE_PROXY_SSL_HEADER')
+USE_X_FORWARDED_HOST = env('USE_X_FORWARDED_HOST', False)


### PR DESCRIPTION
Last little tweak.
Necessary settings when your django app is behind a proxy or a load balancer to detect the https scheme