### PR TITLE
Biosys 403 assign project when signing up

### DIFF
--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -7,6 +7,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.utils import timezone
+from django.conf import settings
 
 from rest_framework import serializers, fields, validators
 from rest_framework_gis import serializers as serializers_gis
@@ -72,7 +73,22 @@ class CreateUserSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         try:
-            return User.objects.create_user(**validated_data)
+            user = User.objects.create_user(**validated_data)
+            # assign new user as custodians of some projects if requested.
+            # look for a 'projects' string or list in the post data
+            # TODO: Should not create the user but return a 400 error if a requested project is not allowed
+            # TODO: use a proper validator
+            requested_project_names = self.context['request'].data['projects']
+            # compare with the server settings allowed public projects
+            allowed_project_names = settings.ALLOWED_PUBLIC_REGISTRATION_PROJECTS
+            if allowed_project_names and requested_project_names:
+                if not isinstance(requested_project_names, list):
+                    requested_project_names = [requested_project_names]
+                for project_name in [p for p in requested_project_names if p in allowed_project_names]:
+                    project = Project.objects.filter(name=project_name).first()
+                    if project is not None:
+                        project.custodians.add(user)
+            return user
         except Exception as e:
             self.fail('cannot create user: {}'.format(e))
 

--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -78,16 +78,18 @@ class CreateUserSerializer(serializers.ModelSerializer):
             # look for a 'projects' string or list in the post data
             # TODO: Should not create the user but return a 400 error if a requested project is not allowed
             # TODO: use a proper validator
-            requested_project_names = self.context['request'].data['projects']
-            # compare with the server settings allowed public projects
-            allowed_project_names = settings.ALLOWED_PUBLIC_REGISTRATION_PROJECTS
-            if allowed_project_names and requested_project_names:
-                if not isinstance(requested_project_names, list):
-                    requested_project_names = [requested_project_names]
-                for project_name in [p for p in requested_project_names if p in allowed_project_names]:
-                    project = Project.objects.filter(name=project_name).first()
-                    if project is not None:
-                        project.custodians.add(user)
+            request_data = self.context['request'].data
+            if 'projects' in request_data:
+                requested_project_names = request_data['projects']
+                # compare with the server settings allowed public projects
+                allowed_project_names = settings.ALLOWED_PUBLIC_REGISTRATION_PROJECTS
+                if allowed_project_names and requested_project_names:
+                    if not isinstance(requested_project_names, list):
+                        requested_project_names = [requested_project_names]
+                    for project_name in [p for p in requested_project_names if p in allowed_project_names]:
+                        project = Project.objects.filter(name=project_name).first()
+                        if project is not None:
+                            project.custodians.add(user)
             return user
         except Exception as e:
             self.fail('cannot create user: {}'.format(e))

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -373,3 +373,6 @@ USE_X_FORWARDED_HOST = env('USE_X_FORWARDED_HOST', False)
 
 # Do we allow public registration?
 ALLOW_PUBLIC_REGISTRATION = env('ALLOW_PUBLIC_REGISTRATION', False)
+# List of projects that a new user can be assign to as a custodian.
+# If empty a new user won't be assigned to any project.
+ALLOWED_PUBLIC_REGISTRATION_PROJECTS = env('ALLOWED_PUBLIC_REGISTRATION_PROJECTS', [])


### PR DESCRIPTION
https://youtrack.gaiaresources.com.au/youtrack/issue/BIOSYS-403

When creating a user a project or a list of project can be sent along the request.
The server controls a 'whitelist' of allowed project to be anonymously assigned.

See the test cases for how to send the projects.