### PR TITLE
add registration email

### DIFF
--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -510,6 +510,10 @@ class WhoamiView(APIView):
 
     def get(self, request, **kwargs):
         data = {}
+        print('whoami call')
+        print(request)
+        print(request.user)
+        print(request.user.is_authenticated)
         if request.user.is_authenticated:
             data = self.serializers(request.user).data
         return Response(data)

--- a/biosys/apps/main/api/views.py
+++ b/biosys/apps/main/api/views.py
@@ -510,10 +510,6 @@ class WhoamiView(APIView):
 
     def get(self, request, **kwargs):
         data = {}
-        print('whoami call')
-        print(request)
-        print(request.user)
-        print(request.user.is_authenticated)
         if request.user.is_authenticated:
             data = self.serializers(request.user).data
         return Response(data)

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -325,11 +325,16 @@ EMAIL_USE_SSL = env('EMAIL_USE_SSL', False)
 EMAIL_SUBJECT_PREFIX = env('EMAIL_SUBJECT_PREFIX', '[BioSys] ')
 EMAIL_USE_LOCALTIME = env('EMAIL_USE_LOCALTIME', False)
 
+SEND_REGISTRATION_CONF = env('SEND_REGISTRATION_CONF', False)
+REGISTRATION_EMAIL_SUBJECT = env('REGISTRATION_EMAIL_SUBJECT', '')
+REGISTRATION_EMAIL_BODY = env('REGISTRATION_EMAIL_BODY', '')
+REGISTRATION_EMAIL_FROM = env('REGISTRATION_EMAIL_FROM', 'hello')
+
 # djoser is used to manage user password reset workflow.
 # see https://djoser.readthedocs.io
 DJOSER = {
     'PASSWORD_RESET_CONFIRM_URL': env('PASSWORD_RESET_CONFIRM_URL', '#/reset-password/{uid}/{token}'),
-    'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': env('PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND', True)
+    'PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND': env('PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND', True),
 }
 # This is use in the email template sent to the user after a reset password request.
 # see https://django-templated-mail.readthedocs.io/en/latest/settings.html#site-name

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ djangorestframework-gis==0.13
 drf-yasg==1.7.4
 django-extra-fields==1.0.0
 Pillow==5.1.0
-djoser==1.2.1
+djoser==1.2.2
 
 # for S3 static/media storage
 django-storages==1.6.6


### PR DESCRIPTION
re: task for koalas (Koala-127) to add a registration email for users, added server settings rather than djoser based on current use of vanilla DRF endpoints and public registration discussions for biosys