### PR TITLE
Add security from pentest oeh

### DIFF
--- a/biosys/apps/main/tests/api/test_user.py
+++ b/biosys/apps/main/tests/api/test_user.py
@@ -559,6 +559,7 @@ class TestPasswordResetWorkflow(helpers.BaseUserTestCase):
         self.assertTrue(user.check_password(new_password))
 
 
+@override_settings(AUTH_PASSWORD_VALIDATORS=[])
 class TestUsername(helpers.BaseUserTestCase):
 
     def test_username_backslash(self):

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -122,6 +122,18 @@ LOGIN_REDIRECT_URL = '/'
 AUTHENTICATION_BACKENDS = env('AUTHENTICATION_BACKENDS', [
     'django.contrib.auth.backends.ModelBackend',
 ])
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': env('PASSWORD_MIN_LENGTH', 8),
+        }
+    },
+]
+EXTRA_PASSWORD_VALIDATORS = env('EXTRA_PASSWORD_VALIDATORS', [])
+AUTH_PASSWORD_VALIDATORS += EXTRA_PASSWORD_VALIDATORS
+
 EXPORTER_CLASS = env('EXPORTER_CLASS', 'main.api.exporters.DefaultExporter')
 
 REST_FRAMEWORK = {

--- a/biosys/urls.py
+++ b/biosys/urls.py
@@ -8,6 +8,8 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.views.generic import TemplateView
 from django.contrib.auth import views as auth_views
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.authentication import BasicAuthentication, SessionAuthentication, TokenAuthentication
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
@@ -70,7 +72,9 @@ schema_view = get_schema_view(
         description="Biosys API Documentation",
     ),
     public=True,
-    patterns=api_urls
+    patterns=api_urls,
+    authentication_classes=(SessionAuthentication, BasicAuthentication, TokenAuthentication),
+    permission_classes=(IsAuthenticated,)
 )
 
 api_doc_urls = [


### PR DESCRIPTION
* Swagger access limited to authenticated user.
* Setup a default but configurable password validator rule. Default is minlength=8. Ability to add more validators through configuration.