### PR TITLE
Split DBCA SSO requirements (which fails) into a separate requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker-compose rm -f
 
 ### Supporting Applications / Packages:
 
+- Python 2.7 or 3.6 (Some dependencies fail on 3.7)
 - PostgreSQL (>=9.3)
 - PostGIS extension (>=2.1)
 - GDAL (>=1.10)

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -84,7 +84,7 @@ MIDDLEWARE = [
 ]
 
 EXTRA_MIDDLEWARE = env('EXTRA_MIDDLEWARE', [
-    'dpaw_utils.middleware.SSOLoginMiddleware'
+    # 'dpaw_utils.middleware.SSOLoginMiddleware'
 ])
 
 MIDDLEWARE += EXTRA_MIDDLEWARE

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,6 @@ djoser==1.2.2
 django-storages==1.6.6
 boto3==1.7.50
 
-# dbca for SSO login
-git+https://github.com/dbca-wa/dpaw-utils.git@0.4.1
-
 # TODO: to get rid of
 django-grappelli==2.8.2
 

--- a/requirements_DBCA.txt
+++ b/requirements_DBCA.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+# dbca for SSO login
+git+https://github.com/dbca-wa/dpaw-utils.git@0.4.1


### PR DESCRIPTION
DBCA packagae for their SSO login is broken. Put it in a separate requirements file for them to deal with it when needed.