### PR TITLE
koala prod: Remove DBCA dependency

### DIFF
--- a/.elasticbeanstalk/config.yml
+++ b/.elasticbeanstalk/config.yml
@@ -13,7 +13,7 @@ branch-defaults:
     environment: biosys-production
   slug_uat:
     environment: biosys-uat
-  slug_produstion:
+  slug_production:
     environment: biosys-production
 global:
   application_name: biosys

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
         - SECRET_KEY=SecretKeyForTravis
         - DATABASE_URL="postgis://postgres@localhost:5432/travis_ci_test"
 install:
-    - sudo apt-get install -y postgresql-9.6-postgis-2.3
+    - sudo apt-get install -y postgresql-9.6-postgis-2.4
     - psql -U postgres -c "create extension if not exists postgis"
     - pip install pip --upgrade
     - pip --version

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker-compose rm -f
 
 ### Supporting Applications / Packages:
 
+- Python 2.7 or 3.6 (Some dependencies fail on 3.7)
 - PostgreSQL (>=9.3)
 - PostGIS extension (>=2.1)
 - GDAL (>=1.10)

--- a/biosys/settings.py
+++ b/biosys/settings.py
@@ -84,7 +84,7 @@ MIDDLEWARE = [
 ]
 
 EXTRA_MIDDLEWARE = env('EXTRA_MIDDLEWARE', [
-    'dpaw_utils.middleware.SSOLoginMiddleware'
+    # 'dpaw_utils.middleware.SSOLoginMiddleware'
 ])
 
 MIDDLEWARE += EXTRA_MIDDLEWARE

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,6 @@ djoser==1.2.2
 django-storages==1.6.6
 boto3==1.7.50
 
-# dbca for SSO login
-git+https://github.com/dbca-wa/dpaw-utils.git@0.4.1
-
 # TODO: to get rid of
 django-grappelli==2.8.2
 

--- a/requirements_DBCA.txt
+++ b/requirements_DBCA.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+# dbca for SSO login
+git+https://github.com/dbca-wa/dpaw-utils.git@0.4.1


### PR DESCRIPTION
The dbca package (git+https://github.com/dbca-wa/dpaw-utils.git@0.4.1) is not accessible anymore.    
5 months ago it was removed from the requirements.txt in the repo.  
Deploy that on oeh prod