### PR TITLE
Updated django admin template tag for django3.x.

### DIFF
--- a/biosys/templates/admin/change_form.html
+++ b/biosys/templates/admin/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n admin_modify admin_urls grp_tags %}
+{% load static i18n admin_modify admin_urls grp_tags %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}


### PR DESCRIPTION
the template tag `admin_static` is not valid anymore. Replaced by just `static`